### PR TITLE
Update Google Benchmark Tag

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -122,7 +122,11 @@ jobs:
     environment: intel_workflow
     steps:
       - uses: actions/checkout@v2
-      - run: pre-commit run --all-files
+        # Add local bin for cpplint
+      - name: Setup
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: pre-commit
+        run: pre-commit run --all-files
 
   build-and-test-icelake:
     name: Build, test and run kernels (IceLake)

--- a/he-samples/cmake/gbenchmark.cmake
+++ b/he-samples/cmake/gbenchmark.cmake
@@ -8,7 +8,7 @@ set(GBENCHMARK_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext_gbenchmark)
 set(GBENCHMARK_SRC_DIR ${GBENCHMARK_PREFIX}/src/ext_gbenchmark/)
 set(GBENCHMARK_BUILD_DIR ${GBENCHMARK_PREFIX}/src/ext_gbenchmark-build/)
 set(GBENCHMARK_REPO_URL https://github.com/google/benchmark.git)
-set(GBENCHMARK_GIT_TAG main)
+set(GBENCHMARK_GIT_TAG v1.5.6)
 
 set(GBENCHMARK_PATHS ${GBENCHMARK_SRC_DIR} ${GBENCHMARK_BUILD_DIR}/src/libbenchmark.a)
 


### PR DESCRIPTION
Solves issue #35 
The HE-Toolkit build was failing to build the latest version of Google Benchmark so opting to change the Git tag from main to the last stable release `v1.5.6`.

Also fixes a minor issue with finding the local PATH on the self-hosted runner.