### PR TITLE
Revert Palisade to last stable release (1.11.3) with HEXL

### DIFF
--- a/docker/setup_and_run_docker.sh
+++ b/docker/setup_and_run_docker.sh
@@ -95,7 +95,7 @@ libs_dir=libs
 
   # HE libs
   git_clone "https://github.com/microsoft/SEAL.git" "3.6.6"
-  git_clone "https://gitlab.com/palisade/palisade-release.git"
+  git_clone "https://gitlab.com/palisade/palisade-release.git" "v1.11.3"
 
   # SEAL dependencies
   git_clone "https://github.com/microsoft/GSL.git"

--- a/docker/utils/gitops.sh
+++ b/docker/utils/gitops.sh
@@ -21,7 +21,5 @@ git_clone() {
     # $opts cannot be quoted.
     # shellcheck disable=SC2086
     git clone $opts "$url"
-  else
-    (cd "$repo" && git pull --ff-only)
   fi
 }


### PR DESCRIPTION
The current latest Palisade release (1.11.4) does not build its HEXL (1.2.0).

We will explicitly be checking out the Palisade 1.11.3 tag as opposed to latest main in docker build until either the HEXL build issue is resolved or a there is a new release of Palisade.

Removing the pull command in `utils/gitops` as this does not work with git tags.