### PR TITLE
Update HElib tag to v2.2.0

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -58,10 +58,19 @@ jobs:
           sudo apt-get install -y libgmp-dev
           sudo apt-get install -y libntl-dev
 
+      # Build and install HEXL 1.2.1 for HElib
+      - name: Install HEXL (for HElib)
+        run: |
+          git clone https://github.com/intel/hexl.git -b v1.2.1
+          cd hexl
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/hexl-install
+          cmake --build build -j
+          cmake --install build
+
       # Build toolkit
       - name: Build the repository
         run: |
-          cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10 -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10 -DCMAKE_BUILD_TYPE=Release -DINTEL_HEXL_HINT_DIR=$GITHUB_WORKSPACE/hexl-install/lib/cmake/hexl-1.2.1
           cmake --build build --target all -j
 
       # Unit tests and examples
@@ -138,7 +147,7 @@ jobs:
       # Build toolkit
       - name: Build the repository
         run: |
-          cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10 -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10 -DCMAKE_BUILD_TYPE=Release -DENABLE_HELIB=OFF
           cmake --build build --target all -j
 
       # Unit tests and examples
@@ -174,3 +183,31 @@ jobs:
           name: ${{github.job}}_sample-kernels-seal_${{github.sha}}.json
           path: he-samples/${{github.job}}_sample-kernels-seal_${{github.sha}}.json
           retention-days: 90 # Maximum for free version
+
+  build-helib-icelake:
+    name: Build HElib with HEXL (Icelake)
+    needs: [format-icelake]
+    runs-on: [self-hosted, Linux, X64, ice-lake]
+    # Use environment protection (require review)
+    environment: intel_workflow
+    defaults:
+      run:
+        shell: bash
+        working-directory: he-samples
+    steps:
+      - uses: actions/checkout@v2
+
+      # Build and install HEXL 1.2.1
+      - name: Build and install HEXL
+        run: |
+          git clone https://github.com/intel/hexl.git -b v1.2.1
+          cd hexl
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/hexl-install
+          cmake --build build -j
+          cmake --install build
+
+      # Build the toolkit with only HElib and HEXL
+      - name: Build HElib
+        run: |
+          cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10 -DCMAKE_BUILD_TYPE=Release -DENABLE_SEAL=OFF -DENABLE_PALISADE=OFF -DENABLE_HELIB=ON -DENABLE_INTEL_HEXL=ON -DINTEL_HEXL_HINT_DIR=$GITHUB_WORKSPACE/hexl-install/lib/cmake/hexl-1.2.1
+          cmake --build build --target all -j

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -11,6 +11,13 @@ on:
   # Manually run this workflow on any specified branch.
   workflow_dispatch:
 
+###################
+# Define env vars #
+###################
+env:
+  HEXL_VER: 1.2.1
+  HEXL_DIR: ${GITHUB_WORKSPACE}/hexl-install/lib/cmake/hexl-${HEXL_VER}
+
 ################
 # Ubuntu 20.04 #
 ################
@@ -61,7 +68,7 @@ jobs:
       # Build and install HEXL 1.2.1 for HElib
       - name: Install HEXL (for HElib)
         run: |
-          git clone https://github.com/intel/hexl.git -b v1.2.1
+          git clone https://github.com/intel/hexl.git -b v${{ env.HEXL_VER }}
           cd hexl
           cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/hexl-install
           cmake --build build -j
@@ -70,7 +77,7 @@ jobs:
       # Build toolkit
       - name: Build the repository
         run: |
-          cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10 -DCMAKE_BUILD_TYPE=Release -DINTEL_HEXL_HINT_DIR=$GITHUB_WORKSPACE/hexl-install/lib/cmake/hexl-1.2.1
+          cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10 -DCMAKE_BUILD_TYPE=Release -DINTEL_HEXL_HINT_DIR=${{ env.HEXL_DIR }}
           cmake --build build --target all -j
 
       # Unit tests and examples
@@ -124,7 +131,7 @@ jobs:
         run: pre-commit run --all-files
 
   build-and-test-icelake:
-    name: Build, test and run kernels (IceLake)
+    name: Build, test and run kernels (IceLake - Excl. HElib)
     needs: [format-icelake]
     runs-on: [self-hosted, Linux, X64, ice-lake]
     # Use environment protection (require review)
@@ -144,7 +151,7 @@ jobs:
           echo $GITHUB_REF
           pwd
 
-      # Build toolkit
+      # Build toolkit (Excl. HElib)
       - name: Build the repository
         run: |
           cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10 -DCMAKE_BUILD_TYPE=Release -DENABLE_HELIB=OFF
@@ -197,10 +204,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Build and install HEXL 1.2.1
+      # Build and install HEXL
       - name: Build and install HEXL
         run: |
-          git clone https://github.com/intel/hexl.git -b v1.2.1
+          git clone https://github.com/intel/hexl.git -b v${{ env.HEXL_VER }}
           cd hexl
           cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/hexl-install
           cmake --build build -j
@@ -209,5 +216,5 @@ jobs:
       # Build the toolkit with only HElib and HEXL
       - name: Build HElib
         run: |
-          cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10 -DCMAKE_BUILD_TYPE=Release -DENABLE_SEAL=OFF -DENABLE_PALISADE=OFF -DENABLE_HELIB=ON -DENABLE_INTEL_HEXL=ON -DINTEL_HEXL_HINT_DIR=$GITHUB_WORKSPACE/hexl-install/lib/cmake/hexl-1.2.1
+          cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10 -DCMAKE_BUILD_TYPE=Release -DENABLE_SEAL=OFF -DENABLE_PALISADE=OFF -DENABLE_HELIB=ON -DENABLE_INTEL_HEXL=ON -DINTEL_HEXL_HINT_DIR=${{ env.HEXL_DIR }}
           cmake --build build --target all -j

--- a/docker/setup_and_run_docker.sh
+++ b/docker/setup_and_run_docker.sh
@@ -94,10 +94,9 @@ libs_dir=libs
   git_clone "https://github.com/intel/hexl.git" "1.1.0-patch"
 
   # HE libs
-  git_clone "https://github.com/microsoft/SEAL.git" "3.6.6"
+  git_clone "https://github.com/microsoft/SEAL.git" "v3.6.6"
   git_clone "https://gitlab.com/palisade/palisade-release.git" "v1.11.3"
-  # FIXME: Set this to pick 2.2.0 release when available
-  git_clone "https://github.com/helibproject/HElib.git"
+  git_clone "https://github.com/homenc/HElib.git" "v2.2.0"
 
   # SEAL dependencies
   git_clone "https://github.com/microsoft/GSL.git"

--- a/he-samples/cmake/helib.cmake
+++ b/he-samples/cmake/helib.cmake
@@ -20,7 +20,7 @@ else()
   set(HELIB_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext_helib)
   set(HELIB_SRC_DIR ${HELIB_PREFIX}/src/ext_helib/)
   set(HELIB_REPO_URL https://github.com/homenc/HElib.git)
-  set(HELIB_GIT_TAG v2.1.0)
+  set(HELIB_GIT_TAG v2.2.0)
 
   set(HELIB_CXX_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
 


### PR DESCRIPTION
Both the docker build and native build will now pick the latest HElib release [v2.2.0](https://github.com/homenc/HElib/releases/tag/v2.2.0).

**NOTE**: Due to HElib 2.2.0 only supporting pre-built HEXL, the CI has been edited to build and install HEXL 1.2.1 and link it directly with HElib through the toolkit.