### PR TITLE
Update PALISADE to v1.11.5

### DIFF
--- a/docker/Dockerfile.toolkit
+++ b/docker/Dockerfile.toolkit
@@ -15,13 +15,7 @@ COPY libs.tar.gz /
 RUN tar -zxvf libs.tar.gz && \
     # Build and install HEXL \
     cd /libs/hexl && \
-    # NOTE: HEXL_EXPORT is removed in versions > 1.1 \
-    cmake -S . -B build -DHEXL_EXPORT=ON && \
-    cmake --build build -j && \
-    cmake --install build && \
-    # Build and install HEXL 1.2.1 for HElib and SEAL \
-    git checkout 1.2.1 && \
-    cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$HOME/hexl-1.2.1/ && \
+    cmake -S . -B build && \
     cmake --build build -j && \
     cmake --install build && \
     # Build and install GSL \
@@ -47,20 +41,20 @@ RUN tar -zxvf libs.tar.gz && \
     cd /libs/SEAL && \
     cmake -S . -B build -DSEAL_BUILD_DEPS=OFF \
                         -DSEAL_USE_INTEL_HEXL=ON \
-                        -DHEXL_DIR=$HOME/hexl-1.2.1/lib/cmake/hexl-1.2.1/ && \
+                        -DHEXL_DIR=/usr/local/lib/cmake/hexl-1.2.1/ && \
     cmake --build build -j && \
     cmake --install build && \
     # Build and install PALISADE \
     cd /libs/palisade-release && \
     cmake -S . -B build -DWITH_INTEL_HEXL=ON \
                         -DINTEL_HEXL_PREBUILT=ON \
-                        -DINTEL_HEXL_HINT_DIR=/usr/local/lib/cmake/ && \
+                        -DINTEL_HEXL_HINT_DIR=/usr/local/lib/cmake/hexl-1.2.1/ && \
     cmake --build build -j && \
     cmake --install build && \
     # Build and install HElib \
     cd /libs/HElib && \
     cmake -S . -B build -DUSE_INTEL_HEXL=ON \
-                        -DHEXL_DIR=$HOME/hexl-1.2.1/lib/cmake/hexl-1.2.1/ && \
+                        -DHEXL_DIR=/usr/local/lib/cmake/hexl-1.2.1/ && \
     cmake --build build -j && \
     cmake --install build
 
@@ -74,7 +68,7 @@ RUN mv /runners /home/$UNAME/ && \
              -DENABLE_HELIB=ON \
     # FIXME: HEXL cmake logic requires re-think \
              -DENABLE_INTEL_HEXL=ON \
-             -DINTEL_HEXL_HINT_DIR=/usr/local/lib/cmake/ \
+             -DINTEL_HEXL_HINT_DIR=/usr/local/lib/cmake/hexl-1.2.1/ \
              -DCMAKE_CXX_COMPILER=clang++-10 \
              -DCMAKE_C_COMPILER=clang-10 \
              -DCMAKE_BUILD_TYPE=Release \

--- a/docker/setup_and_run_docker.sh
+++ b/docker/setup_and_run_docker.sh
@@ -91,11 +91,11 @@ libs_dir=libs
 (# Start subshell
   mkdir -p "$libs_dir" && cd "$libs_dir"
   # HEXL
-  git_clone "https://github.com/intel/hexl.git" "1.1.0-patch"
+  git_clone "https://github.com/intel/hexl.git" "v1.2.1"
 
   # HE libs
   git_clone "https://github.com/microsoft/SEAL.git" "v3.7.0"
-  git_clone "https://gitlab.com/palisade/palisade-release.git" "v1.11.3"
+  git_clone "https://gitlab.com/palisade/palisade-release.git" "v1.11.5"
   git_clone "https://github.com/homenc/HElib.git" "v2.2.0"
 
   # SEAL dependencies

--- a/he-samples/cmake/palisade.cmake
+++ b/he-samples/cmake/palisade.cmake
@@ -40,7 +40,7 @@ else()
   set(PALISADE_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext_palisade)
   set(PALISADE_SRC_DIR ${PALISADE_PREFIX}/src/ext_palisade/)
   set(PALISADE_REPO_URL https://gitlab.com/palisade/palisade-release.git)
-  set(PALISADE_GIT_TAG v1.11.3)
+  set(PALISADE_GIT_TAG v1.11.5)
 
   if (ENABLE_INTEL_HEXL)
     ExternalProject_Add(

--- a/he-samples/cmake/seal.cmake
+++ b/he-samples/cmake/seal.cmake
@@ -8,7 +8,7 @@ message(STATUS "SEAL_PREBUILT: ${SEAL_PREBUILT}")
 
 if (SEAL_PREBUILT) # Skip download from gitlab
   if (ENABLE_INTEL_HEXL)
-    find_package(HEXL 1.1.0 HINTS ${INTEL_HEXL_HINT_DIR} REQUIRED)
+    find_package(HEXL 1.2.1 HINTS ${INTEL_HEXL_HINT_DIR} REQUIRED)
   endif()
   find_package(SEAL 3.7
     HINTS ${SEAL_HINT_DIR}


### PR DESCRIPTION
Update the toolkit to use the latest release of PALISADE v1.11.5 for both the native and docker build.