### PR TITLE
Docker build supported on macOS Catalina

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ contains the current CMake options, default values are in bold.
 `-D<SEAL|PALISADE|HELIB>_HINT_DIR=<path-to-installation>` if you have installed
 them in a non-default location.
 
+**Note:** If opting to use HElib with HEXL enabled, the user must have a
+pre-installed version of HEXL due to HElib currently only supports linking to a
+pre-installed HEXL. See
+[here](https://github.com/homenc/HElib/blob/master/INSTALL.md) for more
+details.
+
 
 ## Kernels
 Located in [he-samples](he-samples) is a collection of software components
@@ -182,6 +188,7 @@ The Intel contributors to this project, sorted by last name, are
   - [Flavio Bergamaschi](https://www.linkedin.com/in/flavio-bergamaschi)
   - [Fabian Boemer](https://www.linkedin.com/in/fabian-boemer-5a40a9102/)
   - [Jeremy Bottleson](https://www.linkedin.com/in/jeremy-bottleson-38852a7/)
+  - Dennis Calderon Vega
   - [Jack Crawford](https://www.linkedin.com/in/jacklhcrawford/) (lead)
   - [Fillipe D.M. de Souza](https://www.linkedin.com/in/fillipe-d-m-de-souza-a8281820/)
   - [Hamish Hunt](https://www.linkedin.com/in/hamish-hunt/)

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 # Pull base image.
@@ -67,7 +67,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.19.2/cmake-3.19.2
     cp -rf cmake_files/bin/* /bin/ && \
     rm -rf cmake_files
     # Install NTL and GMP \
-RUN apt-get install -y libgmp-dev libntl-dev
+RUN apt-get install -y libgmp-dev && \
+    wget https://libntl.org/ntl-11.5.1.tar.gz && \
+    tar xzvf ntl-11.5.1.tar.gz && \
+    cd ntl-11.5.1/src && \
+    ./configure NTL_GMP_LIP=on SHARED=on NTL_THREADS=on NTL_THREAD_BOOST=on TUNE=generic && \
+    make -j && \
+    make install
     # Set timezone to UTC \
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \

--- a/docker/Dockerfile.toolkit
+++ b/docker/Dockerfile.toolkit
@@ -1,10 +1,10 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 # Username
 ARG UNAME
 
-FROM $UNAME/ubuntu_he_base:1.3
+FROM $UNAME/ubuntu_he_base:1.4
 
 ARG UNAME
 
@@ -41,20 +41,22 @@ RUN tar -zxvf libs.tar.gz && \
     cd /libs/SEAL && \
     cmake -S . -B build -DSEAL_BUILD_DEPS=OFF \
                         -DSEAL_USE_INTEL_HEXL=ON \
-                        -DHEXL_DIR=/usr/local/lib/cmake/hexl-1.2.1/ && \
+                        -DHEXL_DIR=/usr/local/lib/cmake/hexl-1.2.3/ && \
     cmake --build build -j && \
     cmake --install build && \
     # Build and install PALISADE \
     cd /libs/palisade-release && \
+    # Apply patch to PALISADE 1.11.5 to allow for use of HEXL 1.2.3 \
+    git apply /he-samples/patches/palisade-hexl.patch && \
     cmake -S . -B build -DWITH_INTEL_HEXL=ON \
                         -DINTEL_HEXL_PREBUILT=ON \
-                        -DINTEL_HEXL_HINT_DIR=/usr/local/lib/cmake/hexl-1.2.1/ && \
+                        -DINTEL_HEXL_HINT_DIR=/usr/local/lib/cmake/hexl-1.2.3/ && \
     cmake --build build -j && \
     cmake --install build && \
     # Build and install HElib \
     cd /libs/HElib && \
     cmake -S . -B build -DUSE_INTEL_HEXL=ON \
-                        -DHEXL_DIR=/usr/local/lib/cmake/hexl-1.2.1/ && \
+                        -DHEXL_DIR=/usr/local/lib/cmake/hexl-1.2.3/ && \
     cmake --build build -j && \
     cmake --install build
 
@@ -68,7 +70,7 @@ RUN mv /runners /home/$UNAME/ && \
              -DENABLE_HELIB=ON \
     # FIXME: HEXL cmake logic requires re-think \
              -DENABLE_INTEL_HEXL=ON \
-             -DINTEL_HEXL_HINT_DIR=/usr/local/lib/cmake/hexl-1.2.1/ \
+             -DINTEL_HEXL_HINT_DIR=/usr/local/lib/cmake/hexl-1.2.3/ \
              -DCMAKE_CXX_COMPILER=clang++-10 \
              -DCMAKE_C_COMPILER=clang-10 \
              -DCMAKE_BUILD_TYPE=Release \

--- a/docker/README.md
+++ b/docker/README.md
@@ -64,6 +64,8 @@ container.
   it is recommended to use a processor with at least Intel AVX512DQ support.
   For best performance, it is recommended to use processors supporting
   AVX512-IFMA52.
+- The docker build has been tested on Ubuntu 20.04 and MacOS Catalina
+  (10.15.7).
 
 ### Steps
 To build and run the Intel HE Toolkit container, from `he-toolkit/docker` run
@@ -90,6 +92,11 @@ This directory will contain the following scripts:
   allowing users to see a faster, more scalable method for LR in HE. Unlike the
   LR code available in the sample-kernels, this version takes extra steps to
   utilize as many slots as possible in the ciphertexts.
+- ***run_psi_example.sh***: This will run a PSI example allowing users to
+  perform a set intersection between a user-defined "client set" and a "server
+  set" (example server sets provided). The program encrypts the client set,
+  computes the intersection, and returns encrypted elements that are common to
+  both sets.
 - ***run_query_example.sh***: This will run a Secure Query example allowing
   users to query on a database of the 50 U.S. States while controlling
   (optionally) the crypto-parameters used. When prompted, enter a State and, if

--- a/docker/README.md
+++ b/docker/README.md
@@ -82,6 +82,14 @@ installation then you can install Docker directly from the official
 [instructions](https://docs.docker.com/engine/install/ubuntu/) to install on
 Ubuntu.
 
+**Note on macOS:** If running the docker build on Mac OSX, the UID and GID of
+the user created in the docker container will both be set to 1000 by default.
+To override this value the user can simply pass in the desired UID/GID as
+follows
+```bash
+./setup_and_run_docker.sh 1234
+```
+
 ## Running the Examples
 After a successful install and build of the docker container, the user should
 be greeted with  welcome message and be inside the container as their user in

--- a/docker/setup_and_run_docker.sh
+++ b/docker/setup_and_run_docker.sh
@@ -71,6 +71,22 @@ readonly version=1.4
 readonly base_label="$user/ubuntu_he_base:$version"
 readonly derived_label="$user/ubuntu_he_test"
 
+USERID="$(id -u)"
+GROUPID="$(id -g)"
+
+# Check for Mac OSX
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [ $# -eq 0 ]; then
+    echo -e "\nWARNING: Detected Mac OSX... Changing UID/GID of docker user to 1000"
+    USERID=1000
+    GROUPID=1000
+  else
+    echo -e "\nWARNING: Changing UID/GID of docker user to $1"
+    GROUPID="$1"
+    GROUPID="$1"
+  fi
+fi
+
 if [ -z "$(docker images -q "$base_label")" ]; then
   echo -e "\nBUILDING BASE DOCKERFILE..."
   docker build \
@@ -79,8 +95,8 @@ if [ -z "$(docker images -q "$base_label")" ]; then
     --build-arg socks_proxy \
     --build-arg ftp_proxy \
     --build-arg no_proxy \
-    --build-arg UID="$(id -u)" \
-    --build-arg GID="1000" \
+    --build-arg UID="$USERID" \
+    --build-arg GID="$GROUPID" \
     --build-arg UNAME="$user" \
     -t "$base_label" \
     -f Dockerfile.base .

--- a/docker/setup_and_run_docker.sh
+++ b/docker/setup_and_run_docker.sh
@@ -43,10 +43,10 @@ source utils/gitops.sh
 
 if [ ! -f "parts.tar.gz" ]; then
   echo -e "\nPACKAGING HE-SAMPLES CODE..."
-  tar -cvzf parts.tar.gz \
+  tar -cvz --exclude he-samples/build \
+    -f parts.tar.gz \
     runners \
     -C "$ROOT" \
-    --exclude he-samples/build \
     he-samples
 fi
 
@@ -80,7 +80,7 @@ if [ -z "$(docker images -q "$base_label")" ]; then
     --build-arg ftp_proxy \
     --build-arg no_proxy \
     --build-arg UID="$(id -u)" \
-    --build-arg GID="$(id -g)" \
+    --build-arg GID="1000" \
     --build-arg UNAME="$user" \
     -t "$base_label" \
     -f Dockerfile.base .

--- a/docker/setup_and_run_docker.sh
+++ b/docker/setup_and_run_docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
@@ -67,7 +67,7 @@ if ! docker run -v \
 fi
 
 readonly user="$(whoami)"
-readonly version=1.3
+readonly version=1.4
 readonly base_label="$user/ubuntu_he_base:$version"
 readonly derived_label="$user/ubuntu_he_test"
 
@@ -91,12 +91,12 @@ libs_dir=libs
 (# Start subshell
   mkdir -p "$libs_dir" && cd "$libs_dir"
   # HEXL
-  git_clone "https://github.com/intel/hexl.git" "v1.2.1"
+  git_clone "https://github.com/intel/hexl.git" "v1.2.3"
 
   # HE libs
-  git_clone "https://github.com/microsoft/SEAL.git" "v3.7.0"
+  git_clone "https://github.com/microsoft/SEAL.git" "v3.7.2"
   git_clone "https://gitlab.com/palisade/palisade-release.git" "v1.11.5"
-  git_clone "https://github.com/homenc/HElib.git" "v2.2.0"
+  git_clone "https://github.com/homenc/HElib.git" "v2.2.1"
 
   # SEAL dependencies
   git_clone "https://github.com/microsoft/GSL.git"


### PR DESCRIPTION
Docker build now works on macOS Catalina (10.15.7).
Includes other bug fixes to docker build and documentation updates.