### PR TITLE
Clean up of copyright years in source

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 # Default codeowner for all files

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 filter=+build,-build/c++11,-build/include_subdir

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-2021 Intel Corporation
+   Copyright 2020 Intel Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 # Pull base image.

--- a/docker/Dockerfile.toolkit
+++ b/docker/Dockerfile.toolkit
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 # Username

--- a/docker/basic-docker-test.sh
+++ b/docker/basic-docker-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/docker/runners/run_lr_example.sh
+++ b/docker/runners/run_lr_example.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/docker/runners/run_psi_example.sh
+++ b/docker/runners/run_psi_example.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/docker/runners/run_query_example.sh
+++ b/docker/runners/run_query_example.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/docker/runners/run_sample_kernels_palisade.sh
+++ b/docker/runners/run_sample_kernels_palisade.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/docker/runners/run_sample_kernels_seal.sh
+++ b/docker/runners/run_sample_kernels_seal.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/docker/runners/run_tests.sh
+++ b/docker/runners/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/docker/setup_and_run_docker.sh
+++ b/docker/setup_and_run_docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/docker/welcome_msg.sh
+++ b/docker/welcome_msg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 cat << EOF

--- a/he-samples/CMakeLists.txt
+++ b/he-samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/he-samples/cmake/gbenchmark.cmake
+++ b/he-samples/cmake/gbenchmark.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 include(ExternalProject)

--- a/he-samples/cmake/gflags.cmake
+++ b/he-samples/cmake/gflags.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 include(ExternalProject)

--- a/he-samples/cmake/gtest.cmake
+++ b/he-samples/cmake/gtest.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 include(ExternalProject)

--- a/he-samples/cmake/palisade.cmake
+++ b/he-samples/cmake/palisade.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 include(ExternalProject)

--- a/he-samples/cmake/seal.cmake
+++ b/he-samples/cmake/seal.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 include(ExternalProject)

--- a/he-samples/examples/CMakeLists.txt
+++ b/he-samples/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 #------------------------------------------------------------------------------

--- a/he-samples/examples/logistic-regression/CMakeLists.txt
+++ b/he-samples/examples/logistic-regression/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 ########################################################

--- a/he-samples/examples/logistic-regression/datasets/CMakeLists.txt
+++ b/he-samples/examples/logistic-regression/datasets/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 ##################################################

--- a/he-samples/examples/logistic-regression/datasets/generate_data.py
+++ b/he-samples/examples/logistic-regression/datasets/generate_data.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """Generate_data
 

--- a/he-samples/examples/logistic-regression/datasets/lr_base.py
+++ b/he-samples/examples/logistic-regression/datasets/lr_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """Logistic Regression base functions
 

--- a/he-samples/examples/logistic-regression/include/data_loader.hpp
+++ b/he-samples/examples/logistic-regression/include/data_loader.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef HE_SAMPLES_EXAMPLES_LOGISTIC_REGRESSION_INCLUDE_DATA_LOADER_HPP_

--- a/he-samples/examples/logistic-regression/include/logger.hpp
+++ b/he-samples/examples/logistic-regression/include/logger.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef HE_SAMPLES_EXAMPLES_LOGISTIC_REGRESSION_INCLUDE_LOGGER_HPP_

--- a/he-samples/examples/logistic-regression/include/lr_helper.hpp
+++ b/he-samples/examples/logistic-regression/include/lr_helper.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef HE_SAMPLES_EXAMPLES_LOGISTIC_REGRESSION_INCLUDE_LR_HELPER_HPP_

--- a/he-samples/examples/logistic-regression/include/lrhe.hpp
+++ b/he-samples/examples/logistic-regression/include/lrhe.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef HE_SAMPLES_EXAMPLES_LOGISTIC_REGRESSION_INCLUDE_LRHE_HPP_

--- a/he-samples/examples/logistic-regression/include/timer.hpp
+++ b/he-samples/examples/logistic-regression/include/timer.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef HE_SAMPLES_EXAMPLES_LOGISTIC_REGRESSION_INCLUDE_UTILS_HPP_

--- a/he-samples/examples/logistic-regression/kernels/CMakeLists.txt
+++ b/he-samples/examples/logistic-regression/kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 # Logistic Regression HE Kernel ops

--- a/he-samples/examples/logistic-regression/kernels/lrhe_kernel.cpp
+++ b/he-samples/examples/logistic-regression/kernels/lrhe_kernel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "lrhe_kernel.hpp"

--- a/he-samples/examples/logistic-regression/kernels/lrhe_kernel.hpp
+++ b/he-samples/examples/logistic-regression/kernels/lrhe_kernel.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef HE_SAMPLES_EXAMPLES_LOGISTIC_REGRESSION_KERNELS_LRHE_KERNEL_HPP_

--- a/he-samples/examples/logistic-regression/kernels/omp_utils.cpp
+++ b/he-samples/examples/logistic-regression/kernels/omp_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "omp_utils.h"

--- a/he-samples/examples/logistic-regression/kernels/omp_utils.h
+++ b/he-samples/examples/logistic-regression/kernels/omp_utils.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef EXAMPLES_LOGISTIC_REGRESSION_KERNELS_OMP_UTILS_H_

--- a/he-samples/examples/logistic-regression/src/data_loader.cpp
+++ b/he-samples/examples/logistic-regression/src/data_loader.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "include/data_loader.hpp"

--- a/he-samples/examples/logistic-regression/src/lr_helper.cpp
+++ b/he-samples/examples/logistic-regression/src/lr_helper.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "include/lr_helper.hpp"

--- a/he-samples/examples/logistic-regression/src/lrhe.cpp
+++ b/he-samples/examples/logistic-regression/src/lrhe.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "include/lrhe.hpp"

--- a/he-samples/examples/logistic-regression/src/main.cpp
+++ b/he-samples/examples/logistic-regression/src/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <seal/seal.h>

--- a/he-samples/examples/logistic-regression/src/timer.cpp
+++ b/he-samples/examples/logistic-regression/src/timer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "include/timer.hpp"

--- a/he-samples/examples/psi/CMakeLists.txt
+++ b/he-samples/examples/psi/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 #####################################################################

--- a/he-samples/examples/psi/psi.cpp
+++ b/he-samples/examples/psi/psi.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <helib/ArgMap.h>

--- a/he-samples/examples/secure-query/CMakeLists.txt
+++ b/he-samples/examples/secure-query/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 #####################################################################

--- a/he-samples/examples/secure-query/include/sq_helper_functions.h
+++ b/he-samples/examples/secure-query/include/sq_helper_functions.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef HE_SAMPLES_EXAMPLES_SECURE_QUERY_INCLUDE_SQ_HELPER_FUNCTIONS_H_

--- a/he-samples/examples/secure-query/include/sq_types.h
+++ b/he-samples/examples/secure-query/include/sq_types.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef HE_SAMPLES_EXAMPLES_SECURE_QUERY_INCLUDE_SQ_TYPES_H_

--- a/he-samples/examples/secure-query/include/sqclient.h
+++ b/he-samples/examples/secure-query/include/sqclient.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/examples/secure-query/include/sqserver.h
+++ b/he-samples/examples/secure-query/include/sqserver.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/examples/secure-query/include/timer.h
+++ b/he-samples/examples/secure-query/include/timer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/examples/secure-query/src/main.cpp
+++ b/he-samples/examples/secure-query/src/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>

--- a/he-samples/examples/secure-query/src/sqclient.cpp
+++ b/he-samples/examples/secure-query/src/sqclient.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sqclient.h"

--- a/he-samples/examples/secure-query/src/sqserver.cpp
+++ b/he-samples/examples/secure-query/src/sqserver.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sqserver.h"

--- a/he-samples/sample-kernels/CMakeLists.txt
+++ b/he-samples/sample-kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set(SAMPLE_KERNELS_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/he-samples/sample-kernels/kernel_util.h
+++ b/he-samples/sample-kernels/kernel_util.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/kernels/CMakeLists.txt
+++ b/he-samples/sample-kernels/kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 # PALISADE ops

--- a/he-samples/sample-kernels/kernels/omp_utils.h
+++ b/he-samples/sample-kernels/kernels/omp_utils.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/kernels/palisade/omp_utils_palisade.cpp
+++ b/he-samples/sample-kernels/kernels/palisade/omp_utils_palisade.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "omp_utils_palisade.h"

--- a/he-samples/sample-kernels/kernels/palisade/omp_utils_palisade.h
+++ b/he-samples/sample-kernels/kernels/palisade/omp_utils_palisade.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/kernels/palisade/palisade_bfv_kernel_executor.cpp
+++ b/he-samples/sample-kernels/kernels/palisade/palisade_bfv_kernel_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "kernels/palisade/palisade_bfv_kernel_executor.h"

--- a/he-samples/sample-kernels/kernels/palisade/palisade_bfv_kernel_executor.h
+++ b/he-samples/sample-kernels/kernels/palisade/palisade_bfv_kernel_executor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/kernels/palisade/palisade_ckks_kernel_executor.cpp
+++ b/he-samples/sample-kernels/kernels/palisade/palisade_ckks_kernel_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "kernels/palisade/palisade_ckks_kernel_executor.h"

--- a/he-samples/sample-kernels/kernels/palisade/palisade_ckks_kernel_executor.h
+++ b/he-samples/sample-kernels/kernels/palisade/palisade_ckks_kernel_executor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/kernels/palisade/palisade_omp_utils.cpp
+++ b/he-samples/sample-kernels/kernels/palisade/palisade_omp_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "palisade_omp_utils.h"

--- a/he-samples/sample-kernels/kernels/palisade/palisade_omp_utils.h
+++ b/he-samples/sample-kernels/kernels/palisade/palisade_omp_utils.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/kernels/palisade/palisade_util.h
+++ b/he-samples/sample-kernels/kernels/palisade/palisade_util.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <palisade.h>

--- a/he-samples/sample-kernels/kernels/seal/seal_bfv_context.cpp
+++ b/he-samples/sample-kernels/kernels/seal/seal_bfv_context.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "kernels/seal/seal_bfv_context.h"

--- a/he-samples/sample-kernels/kernels/seal/seal_bfv_context.h
+++ b/he-samples/sample-kernels/kernels/seal/seal_bfv_context.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/kernels/seal/seal_bfv_kernel_executor.cpp
+++ b/he-samples/sample-kernels/kernels/seal/seal_bfv_kernel_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "kernels/seal/seal_bfv_kernel_executor.h"

--- a/he-samples/sample-kernels/kernels/seal/seal_bfv_kernel_executor.h
+++ b/he-samples/sample-kernels/kernels/seal/seal_bfv_kernel_executor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/kernels/seal/seal_ckks_context.cpp
+++ b/he-samples/sample-kernels/kernels/seal/seal_ckks_context.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "kernels/seal/seal_ckks_context.h"

--- a/he-samples/sample-kernels/kernels/seal/seal_ckks_context.h
+++ b/he-samples/sample-kernels/kernels/seal/seal_ckks_context.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/kernels/seal/seal_ckks_kernel_executor.cpp
+++ b/he-samples/sample-kernels/kernels/seal/seal_ckks_kernel_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "kernels/seal/seal_ckks_kernel_executor.h"

--- a/he-samples/sample-kernels/kernels/seal/seal_ckks_kernel_executor.h
+++ b/he-samples/sample-kernels/kernels/seal/seal_ckks_kernel_executor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/kernels/seal/seal_omp_utils.cpp
+++ b/he-samples/sample-kernels/kernels/seal/seal_omp_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "seal_omp_utils.h"

--- a/he-samples/sample-kernels/kernels/seal/seal_omp_utils.h
+++ b/he-samples/sample-kernels/kernels/seal/seal_omp_utils.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/he-samples/sample-kernels/main.cpp
+++ b/he-samples/sample-kernels/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>

--- a/he-samples/sample-kernels/palisade/palisade_bfv_sample.cpp
+++ b/he-samples/sample-kernels/palisade/palisade_bfv_sample.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>

--- a/he-samples/sample-kernels/palisade/palisade_ckks_sample.cpp
+++ b/he-samples/sample-kernels/palisade/palisade_ckks_sample.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>

--- a/he-samples/sample-kernels/palisade/palisade_util.h
+++ b/he-samples/sample-kernels/palisade/palisade_util.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <palisade.h>

--- a/he-samples/sample-kernels/seal/seal_bfv_sample.cpp
+++ b/he-samples/sample-kernels/seal/seal_bfv_sample.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>

--- a/he-samples/sample-kernels/seal/seal_ckks_sample.cpp
+++ b/he-samples/sample-kernels/seal/seal_ckks_sample.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>

--- a/he-samples/sample-kernels/test/CMakeLists.txt
+++ b/he-samples/sample-kernels/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set(SRC main.cpp)

--- a/he-samples/sample-kernels/test/main.cpp
+++ b/he-samples/sample-kernels/test/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>

--- a/he-samples/sample-kernels/test/test_palisade.cpp
+++ b/he-samples/sample-kernels/test/test_palisade.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>

--- a/he-samples/sample-kernels/test/test_palisade_bfv_kernel_executor.cpp
+++ b/he-samples/sample-kernels/test/test_palisade_bfv_kernel_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>

--- a/he-samples/sample-kernels/test/test_palisade_ckks_kernel_executor.cpp
+++ b/he-samples/sample-kernels/test/test_palisade_ckks_kernel_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>

--- a/he-samples/sample-kernels/test/test_seal.cpp
+++ b/he-samples/sample-kernels/test/test_seal.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>

--- a/he-samples/sample-kernels/test/test_seal_bfv_kernel_executor.cpp
+++ b/he-samples/sample-kernels/test/test_seal_bfv_kernel_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>

--- a/he-samples/sample-kernels/test/test_seal_ckks_kernel_executor.cpp
+++ b/he-samples/sample-kernels/test/test_seal_ckks_kernel_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>

--- a/he-samples/sample-kernels/test/test_util.h
+++ b/he-samples/sample-kernels/test/test_util.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once


### PR DESCRIPTION
Following guidance, all copyright years will now be just the year of the creation of the file.