### PR TITLE
VS Code (code-server) via Docker

### DIFF
--- a/docker/Dockerfile.toolkit
+++ b/docker/Dockerfile.toolkit
@@ -4,7 +4,7 @@
 # Username
 ARG UNAME
 
-FROM $UNAME/ubuntu_he_base:1.4
+FROM $UNAME/ubuntu_he_base:2.0
 
 ARG UNAME
 

--- a/docker/Dockerfile.vscode
+++ b/docker/Dockerfile.vscode
@@ -1,0 +1,46 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Username
+ARG UNAME
+
+FROM $UNAME/ubuntu_he_test:latest
+
+ARG UNAME
+
+LABEL maintainer="https://github.com/intel/he-toolkit"
+
+# code-server runs on HTTPS port 8888
+EXPOSE 8888/tcp
+
+# Do the following as root
+USER root
+
+# Download and install the latest version of code-server
+RUN curl -fsSL https://code-server.dev/install.sh | sh
+
+# Create space for IDE settings
+RUN mkdir -p /opt/Intel-HE-Toolkit/HE-Workspace/User && \
+    mkdir -p /opt/Intel-HE-Toolkit/HE-Workspace/.vscode && \
+    # Change ownership of files to user \
+    chown -R $UNAME:$UNAME /opt/Intel-HE-Toolkit
+
+# Change back to user for remaining installation
+USER $UNAME
+
+# Workspace settings for code-server IDE
+COPY --chown=$UNAME:$UNAME ./IDE-Config /opt/Intel-HE-Toolkit/HE-Workspace/.vscode/
+
+# Move he-samples into HE-Workspace
+RUN cp -rp /home/$UNAME/he-samples /opt/Intel-HE-Toolkit/HE-Workspace && \
+    rm -rf /opt/Intel-HE-Toolkit/HE-Workspace/he-samples/build
+
+# Install code-server extensions
+RUN for e in vscode.cpp twxs.cmake ms-vscode.cmake-tools; do \
+      code-server --user-data-dir=/opt/Intel-HE-Toolkit/HE-Workspace/ --install-extension $e; \
+    done
+
+# Update code-server user settings
+RUN echo "{\"extensions.autoUpdate\": false,\n\"workbench.colorTheme\": \"Default Dark+\"}" > /opt/Intel-HE-Toolkit/HE-Workspace/User/settings.json
+
+ENTRYPOINT ["code-server", "/opt/Intel-HE-Toolkit/HE-Workspace", "--bind-addr", "0.0.0.0:8888", "--user-data-dir", "/opt/Intel-HE-Toolkit/HE-Workspace", "--auth", "none", "--disable-telemetry"]

--- a/docker/Dockerfile.vscode
+++ b/docker/Dockerfile.vscode
@@ -36,7 +36,7 @@ RUN cp -rp /home/$UNAME/he-samples /opt/Intel-HE-Toolkit/HE-Workspace && \
     rm -rf /opt/Intel-HE-Toolkit/HE-Workspace/he-samples/build
 
 # Install code-server extensions
-RUN for e in vscode.cpp twxs.cmake ms-vscode.cmake-tools; do \
+RUN for e in vscode.cpp twxs.cmake ms-vscode.cmake-tools vadimcn.vscode-lldb; do \
       code-server --user-data-dir=/opt/Intel-HE-Toolkit/HE-Workspace/ --install-extension $e; \
     done
 

--- a/docker/Dockerfile.vscode
+++ b/docker/Dockerfile.vscode
@@ -41,6 +41,8 @@ RUN for e in vscode.cpp twxs.cmake ms-vscode.cmake-tools vadimcn.vscode-lldb; do
     done
 
 # Update code-server user settings
-RUN echo "{\"extensions.autoUpdate\": false,\n\"workbench.colorTheme\": \"Default Dark+\"}" > /opt/Intel-HE-Toolkit/HE-Workspace/User/settings.json
+RUN echo "{\"extensions.autoUpdate\": false,\n\"workbench.colorTheme\": \"Default Dark+\"}" > /opt/Intel-HE-Toolkit/HE-Workspace/User/settings.json && \
+    # Create a randomly generated self-signed certificate for code-server \
+    sed -i.bak 's/cert: false/cert: true/' /home/$UNAME/.config/code-server/config.yaml
 
 ENTRYPOINT ["code-server", "/opt/Intel-HE-Toolkit/HE-Workspace", "--bind-addr", "0.0.0.0:8888", "--user-data-dir", "/opt/Intel-HE-Toolkit/HE-Workspace", "--auth", "none", "--disable-telemetry"]

--- a/docker/IDE-Config/settings.json
+++ b/docker/IDE-Config/settings.json
@@ -1,0 +1,16 @@
+{
+  "terminal.integrated.defaultProfile.linux": "bash",
+  "cmake.sourceDirectory": "${workspaceFolder}/he-samples",
+  "cmake.configureOnOpen": true,
+  "cmake.configureSettings": {
+    "SEAL_PREBUILT": "ON",
+    "PALISADE_PREBUILT": "ON",
+    "HELIB_PREBUILT": "ON",
+    "SEAL_HINT_DIR": "~/.hekit/components/seal/v3.7.2/install/lib/cmake/SEAL-3.7/",
+    "PALISADE_HINT_DIR": "~/.hekit/components/palisade/v1.11.6/install/lib/Palisade/",
+    "HELIB_HINT_DIR": "~/.hekit/components/helib/v2.2.1/install/share/cmake/helib/",
+    "INTEL_HEXL_HINT_DIR": "~/.hekit/components/hexl/1.2.3/install/lib/cmake/hexl-1.2.3/",
+    "Microsoft.GSL_DIR": "~/.hekit/components/gsl/v3.1.0/install/share/cmake/Microsoft.GSL",
+    "zstd_DIR": "~/.hekit/components/zstd/v1.4.5/install/lib/cmake/zstd"
+  }
+}

--- a/docker/setup_and_run_docker.sh
+++ b/docker/setup_and_run_docker.sh
@@ -67,7 +67,7 @@ if ! docker run -v \
 fi
 
 readonly user="$(whoami)"
-readonly version=1.4
+readonly version=2.0
 readonly base_label="$user/ubuntu_he_base:$version"
 readonly derived_label="$user/ubuntu_he_test"
 
@@ -82,7 +82,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     GROUPID=1000
   else
     echo -e "\nWARNING: Changing UID/GID of docker user to $1"
-    GROUPID="$1"
+    USERID="$1"
     GROUPID="$1"
   fi
 fi

--- a/docker/vscode.sh
+++ b/docker/vscode.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+readonly user="$(whoami)"
+readonly vscode_label="$user/ubuntu_he_vscode"
+
+echo -e "\nBUILDING VSCODE DOCKERFILE..."
+docker build \
+  --build-arg UNAME="$user" \
+  -t "$vscode_label" \
+  -f Dockerfile.vscode .
+
+echo -e "\nRUN DOCKER CONTAINER..."
+docker run -d -p 8888:8888 "$vscode_label"
+
+echo -e "\nDOCKER CONTAINER BUILT SUCCESSFULLY\nTO OPEN VSCODE NAVIGATE TO localhost:8888 IN YOUR CHOSEN BROWSER"


### PR DESCRIPTION
Users can now use [code-server](https://github.com/coder/code-server) to have VS Code in the browser via the Docker build.
Other minor changes/fixes were made to the docker files/scripts.