### PR TITLE
Extend Toolkit CI

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -98,9 +98,8 @@ jobs:
       # TODO: Remove this once there is !! substitution
       - name: Modify paths in recipe files
         run: |
-          echo ${GITHUB_WORKSPACE}
-          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1${GITHUB_WORKSPACE}/g" recipes/examples.toml
-          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1${GITHUB_WORKSPACE}/g" recipes/sample-kernels.toml
+          sed -i -e "s,\(src_dir = \"\)~/git/public-toolkit/v2-prep,\1${GITHUB_WORKSPACE},g" recipes/examples.toml
+          sed -i -e "s,\(src_dir = \"\)~/git/public-toolkit/v2-prep,\1${GITHUB_WORKSPACE},g" recipes/sample-kernels.toml
 
       - name: Build examples
         run: ./hekit build recipes/examples.toml
@@ -208,8 +207,9 @@ jobs:
       # TODO: Remove this once there is !! substitution
       - name: Modify paths in recipe files
         run: |
-          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1${GITHUB_WORKSPACE}/g" recipes/examples.toml
-          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1${GITHUB_WORKSPACE}/g" recipes/sample-kernels.toml
+          echo ${GITHUB_WORKSPACE}
+          sed -i -e "s,\(src_dir = \"\)~/git/public-toolkit/v2-prep,\1${GITHUB_WORKSPACE},g" recipes/examples.toml
+          sed -i -e "s,\(src_dir = \"\)~/git/public-toolkit/v2-prep,\1${GITHUB_WORKSPACE},g" recipes/sample-kernels.toml
 
       - name: Build examples
         run: ./hekit build recipes/examples.toml

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -217,9 +217,9 @@ jobs:
 
       - name: Run PSI example
         run: |
-          echo -e "apple\nBanana\ncat\nRa\nCalifornia" > client.set
+          echo -e "apple\nBanana\ncat\nBa-Ra\nCalifornia" > client.set
           ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/fruits.set | grep -B 1 "apple"
-          ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/ancient_egyptian_gods.set | grep -B 1 "Ra"
+          ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/ancient_egyptian_gods.set | grep -B 1 "Ba-Ra"
           ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/us_states.set | grep -B 1 "California"
 
       - name: Run Secure Query example

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -211,10 +211,9 @@ jobs:
         run: |
           ./hekit build recipes/examples.toml
           ./hekit list
-          echo "EXAMPLES_DIR=$HOME/.hekit/components/examples" >> $GITHUB_ENV
-          echo "PSI_BUILD_DIR=$EXAMPLES_DIR/psi/build" >> $GITHUB_ENV
-          echo "QUERY_BUILD_DIR=$EXAMPLES_DIR/secure-query/build" >> $GITHUB_ENV
-          echo "LR_BUILD_DIR=$EXAMPLES_DIR/logitic-regression/build" >> $GITHUB_ENV
+          echo "PSI_BUILD_DIR=$HOME/.hekit/components/examples/psi/build" >> $GITHUB_ENV
+          echo "QUERY_BUILD_DIR=$HOME/.hekit/components/example/secure-query/build" >> $GITHUB_ENV
+          echo "LR_BUILD_DIR=$HOME/.hekit/components/example/logitic-regression/build" >> $GITHUB_ENV
 
       - name: Run PSI example
         run: |
@@ -235,9 +234,8 @@ jobs:
         run: |
           ./hekit build recipes/sample-kernels.toml
           ./hekit list
-          echo "KERNELS_DIR=$HOME/.hekit/components/sample-kernels" >> $GITHUB_ENV
-          echo "SEAL_KERNELS_BUILD_DIR=$KERNELS_DIR/seal/build" >> $GITHUB_ENV
-          echo "PALISADE_KERNELS_BUILD_DIR=$KERNELS_DIR/palisade/build" >> $GITHUB_ENV
+          echo "SEAL_KERNELS_BUILD_DIR=$HOME/.hekit/components/sample-kernels/seal/build" >> $GITHUB_ENV
+          echo "PALISADE_KERNELS_BUILD_DIR=$HOME/.hekit/components/sample-kernels/palisade/build" >> $GITHUB_ENV
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -71,6 +71,7 @@ jobs:
         run: pytest tests/
 
   build-and-test-toolkit:
+    if: ${{ false }} # FIXME: Disable this job for now
     name: Build, test and run HE Toolkit
     runs-on: ubuntu-20.04
     # Use environment protection (require review)

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -94,38 +94,52 @@ jobs:
       # TODO: Remove this once there is !! substitution
       - name: Modify paths in recipe files
         run: |
+          echo ${GITHUB_WORKSPACE}
           sed -i -e "s,\(src_dir = \"\)~/git/public-toolkit/v2-prep,\1${GITHUB_WORKSPACE},g" recipes/examples.toml
           sed -i -e "s,\(src_dir = \"\)~/git/public-toolkit/v2-prep,\1${GITHUB_WORKSPACE},g" recipes/sample-kernels.toml
 
       - name: Build examples
-        run: ./hekit build recipes/examples.toml
+        run: |
+          ./hekit build recipes/examples.toml
+          ./hekit list
+          echo "PSI_BUILD_DIR=$HOME/.hekit/components/examples/psi/build" >> $GITHUB_ENV
+          echo "QUERY_BUILD_DIR=$HOME/.hekit/components/examples/secure-query/build" >> $GITHUB_ENV
+          echo "LR_BUILD_DIR=$HOME/.hekit/components/examples/logistic-regression/build" >> $GITHUB_ENV
 
       - name: Run PSI example
         run: |
-          echo "apple\nBanana\ncat" > client.set
-          ${{ env.PSI_DIR }}/build/psi client.set --server ${{ env.PSI_DIR }}/build/datasets/fruits.set | grep -B 1 "apple"
+          echo -e "apple\nBanana\ncat\nBa-Ra\nCalifornia" > client.set
+          ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/fruits.set | grep -B 1 "apple"
+          ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/ancient_egyptian_gods.set | grep -B 1 "Ba-Ra"
+          ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/us_states.set | grep -B 1 "California"
 
       - name: Run Secure Query example
         run: |
-          cd ${{ env.QUERY_DIR }}/build
+          cd ${QUERY_BUILD_DIR}
           echo -n "Input: Louisiana, " && ./secure-query <<< $'\n\nLouisiana\n' | grep "Baton Rouge"
           echo -n "Input: North Dakota, " && ./secure-query <<< $'\n\nNorth Dakota\n' | grep "Bismarck"
           echo -n "Input: Wyoming, " && ./secure-query <<< $'\n\nWyoming\n' | grep "Cheyenne"
 
       - name: Run LR example
-        run: ${{ env.LR_DIR }}/build/lr_test --compare --data lrtest_large | grep "All match!"
+        run: |
+          cd ${LR_BUILD_DIR}
+          ./lr_test --compare --data lrtest_large | grep "All match!"
 
       - name: Build sample kernels
-        run: ./hekit build recipes/sample-kernels.toml
+        run: |
+          ./hekit build recipes/sample-kernels.toml
+          ./hekit list
+          echo "SEAL_KERNELS_BUILD_DIR=$HOME/.hekit/components/sample-kernels/seal/build" >> $GITHUB_ENV
+          echo "PALISADE_KERNELS_BUILD_DIR=$HOME/.hekit/components/sample-kernels/palisade/build" >> $GITHUB_ENV
 
       - name: Run unit tests
         run: |
-          ${{ env.SEAL_KERNELS_DIR }}/build/test/unit-test
-          ${{ env.PALISADE_KERNELS_DIR }}/build test/unit-test
+          ${SEAL_KERNELS_BUILD_DIR}/test/unit-test
+          ${PALISADE_KERNELS_BUILD_DIR}/test/unit-test
 
       # PALISADE sample kernels
       - name: Run PALISADE sample kernels
-        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${{ env.PALISADE_KERNELS_DIR }}/build/sample-kernels-palisade --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-palisade_${GITHUB_SHA}.json"
+        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${PALISADE_KERNELS_BUILD_DIR}/sample-kernels-palisade --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-palisade_${GITHUB_SHA}.json"
       - name: Archive PALISADE sample kernel results
         uses: actions/upload-artifact@v2
         with:
@@ -135,7 +149,7 @@ jobs:
 
       # SEAL sample kernels
       - name: Run SEAL sample kernels
-        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${{ env.SEAL_KERNELS_DIR }}/build/sample-kernels-seal --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-seal_${GITHUB_SHA}.json"
+        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${SEAL_KERNELS_BUILD_DIR}/sample-kernels-seal --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-seal_${GITHUB_SHA}.json"
       - name: Archive SEAL sample kernel results
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Run PSI example
         run: |
-          echo "apple\nBanana\ncat" > client.set
+          echo -e "apple\nBanana\ncat" > client.set
           ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/fruits.set | grep -B 1 "apple"
 
       - name: Run Secure Query example

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -20,7 +20,7 @@ env:
   SEAL_VER: 3.7.2
   PALISADE_VER: 1.11.6
   HELIB_VER: 2.2.1
-  HEKIT_DIR: ~/.hekit/components
+  HEKIT_DIR: $HOME/.hekit/components
   HEXL_DIR: ${HEKIT_DIR}/hexl/${HEXL_VER}/lib/cmake/hexl-${HEXL_VER}
   SEAL_DIR: ${HEKIT_DIR}/seal/v${SEAL_VER}/install/lib/cmake/SEAL-3.7
   PALISADE_DIR: ${HEKIT_DIR}/palisade/v${PALISADE_VER}/install/lib/Palisade
@@ -217,15 +217,14 @@ jobs:
           ./hekit build recipes/examples.toml
           ./hekit list
 
-          #- name: Run PSI example
-          #  run: |
-          #    echo "apple\nBanana\ncat" > client.set
-          #    ${{ env.PSI_DIR }}/build/psi client.set --server ${{ env.PSI_DIR }}/build/datasets/fruits.set | grep -B 1 "apple"
+      - name: Run PSI example
+        run: |
+          echo "apple\nBanana\ncat" > client.set
+          ${{ env.PSI_DIR }}/build/psi client.set --server ${{ env.PSI_DIR }}/build/datasets/fruits.set | grep -B 1 "apple"
 
       - name: Run Secure Query example
         run: |
-          #cd ${{ env.QUERY_DIR }}/build
-          cd $HOME/.hekit/components/examples/secure-query/build
+          cd ${{ env.QUERY_DIR }}/build
           echo -n "Input: Louisiana, " && ./secure-query <<< $'\n\nLouisiana\n' | grep "Baton Rouge"
           echo -n "Input: North Dakota, " && ./secure-query <<< $'\n\nNorth Dakota\n' | grep "Bismarck"
           echo -n "Input: Wyoming, " && ./secure-query <<< $'\n\nWyoming\n' | grep "Cheyenne"

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -230,7 +230,9 @@ jobs:
           echo -n "Input: Wyoming, " && ./secure-query <<< $'\n\nWyoming\n' | grep "Cheyenne"
 
       - name: Run LR example
-        run: ${LR_BUILD_DIR}/lr_test --compare --data lrtest_large | grep "All match!"
+        run: |
+          cd ${LR_BUILD_DIR}
+          ./lr_test --compare --data lrtest_large | grep "All match!"
 
       - name: Build sample kernels
         run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -20,18 +20,13 @@ env:
   SEAL_VER: 3.7.2
   PALISADE_VER: 1.11.6
   HELIB_VER: 2.2.1
-  HEKIT_DIR: $HOME/.hekit/components
+  HEKIT_DIR: ~/.hekit/components
   HEXL_DIR: ${HEKIT_DIR}/hexl/${HEXL_VER}/lib/cmake/hexl-${HEXL_VER}
   SEAL_DIR: ${HEKIT_DIR}/seal/v${SEAL_VER}/install/lib/cmake/SEAL-3.7
   PALISADE_DIR: ${HEKIT_DIR}/palisade/v${PALISADE_VER}/install/lib/Palisade
   HELIB_DIR: ${HEKIT_DIR}/helib/v${HELIB_VER}/share/cmake/helib
   GSL_DIR: ${HEKIT_DIR}/gsl/v3.1.0/install/share/cmake/Microsoft.GSL
   ZSTD_DIR: ${HEKIT_DIR}/zstd/v1.4.5/install/lib/cmake/zstd
-  PSI_DIR: ${HEKIT_DIR}/examples/psi
-  QUERY_DIR: ${HEKIT_DIR}/examples/secure-query
-  LR_DIR: ${HEKIT_DIR}/examples/logistic-regression
-  SEAL_KERNELS_DIR: ${HEKIT_DIR}/sample-kernels/seal
-  PALISADE_KERNELS_DIR: ${HEKIT_DIR/sample-kernels/palisade
 
 ################
 # Ubuntu 20.04 #
@@ -216,35 +211,42 @@ jobs:
         run: |
           ./hekit build recipes/examples.toml
           ./hekit list
+          echo "EXAMPLES_DIR=$HOME/.hekit/components/examples >> $GITHUB_ENV"
+          echo "PSI_BUILD_DIR=$EXAMPLES_DIR/psi/build >> $GITHUB_ENV"
+          echo "QUERY_BUILD_DIR=$EXAMPLES_DIR/secure-query/build >> $GITHUB_ENV"
+          echo "LR_BUILD_DIR=$EXAMPLES_DIR/logitic-regression/build >> $GITHUB_ENV"
 
       - name: Run PSI example
         run: |
           echo "apple\nBanana\ncat" > client.set
-          ${{ env.PSI_DIR }}/build/psi client.set --server ${{ env.PSI_DIR }}/build/datasets/fruits.set | grep -B 1 "apple"
+          ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/fruits.set | grep -B 1 "apple"
 
       - name: Run Secure Query example
         run: |
-          cd ${{ env.QUERY_DIR }}/build
+          cd ${QUERY_BUILD_DIR}
           echo -n "Input: Louisiana, " && ./secure-query <<< $'\n\nLouisiana\n' | grep "Baton Rouge"
           echo -n "Input: North Dakota, " && ./secure-query <<< $'\n\nNorth Dakota\n' | grep "Bismarck"
           echo -n "Input: Wyoming, " && ./secure-query <<< $'\n\nWyoming\n' | grep "Cheyenne"
 
       - name: Run LR example
-        run: ${{ env.LR_DIR }}/build/lr_test --compare --data lrtest_large | grep "All match!"
+        run: ${LR_BUILD_DIR}/lr_test --compare --data lrtest_large | grep "All match!"
 
       - name: Build sample kernels
         run: |
           ./hekit build recipes/sample-kernels.toml
           ./hekit list
+          echo "KERNELS_DIR=$HOME/.hekit/components/sample-kernels >> $GITHUB_ENV"
+          echo "SEAL_KERNELS_BUILD_DIR=$KERNELS_DIR/seal/build >> $GITHUB_ENV"
+          echo "PALISADE_KERNELS_BUILD_DIR=$KERNELS_DIR/palisade/build >> $GITHUB_ENV"
 
       - name: Run unit tests
         run: |
-          ${{ env.SEAL_KERNELS_DIR }}/build/test/unit-test
-          ${{ env.PALISADE_KERNELS_DIR }}/build test/unit-test
+          ${SEAL_KERNELS_BUILD_DIR}/test/unit-test
+          ${PALISADE_KERNELS_BUILD_DIR}/test/unit-test
 
       # PALISADE sample kernels
       - name: Run PALISADE sample kernels
-        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${{ env.PALISADE_KERNELS_DIR }}/build/sample-kernels-palisade --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-palisade_${GITHUB_SHA}.json"
+        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${PALISADE_KERNELS_BUILD_DIR}/sample-kernels-palisade --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-palisade_${GITHUB_SHA}.json"
       - name: Archive PALISADE sample kernel results
         uses: actions/upload-artifact@v2
         with:
@@ -254,7 +256,7 @@ jobs:
 
       # SEAL sample kernels
       - name: Run SEAL sample kernels
-        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${{ env.SEAL_KERNELS_DIR }}/build/sample-kernels-seal --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-seal_${GITHUB_SHA}.json"
+        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${SEAL_KERNELS_BUILD_DIR}/sample-kernels-seal --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-seal_${GITHUB_SHA}.json"
       - name: Archive SEAL sample kernel results
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -213,7 +213,7 @@ jobs:
           ./hekit list
           echo "PSI_BUILD_DIR=$HOME/.hekit/components/examples/psi/build" >> $GITHUB_ENV
           echo "QUERY_BUILD_DIR=$HOME/.hekit/components/examples/secure-query/build" >> $GITHUB_ENV
-          echo "LR_BUILD_DIR=$HOME/.hekit/components/examples/logitic-regression/build" >> $GITHUB_ENV
+          echo "LR_BUILD_DIR=$HOME/.hekit/components/examples/logistic-regression/build" >> $GITHUB_ENV
 
       - name: Run PSI example
         run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -213,12 +213,14 @@ jobs:
           sed -i -e "s,\(src_dir = \"\)~/git/public-toolkit/v2-prep,\1${GITHUB_WORKSPACE},g" recipes/sample-kernels.toml
 
       - name: Build examples
-        run: ./hekit build recipes/examples.toml
-
-      - name: Run PSI example
         run: |
-          echo "apple\nBanana\ncat" > client.set
-          ${{ env.PSI_DIR }}/build/psi client.set --server ${{ env.PSI_DIR }}/build/datasets/fruits.set | grep -B 1 "apple"
+          ./hekit build recipes/examples.toml
+          ./hekit list
+
+          #- name: Run PSI example
+          #  run: |
+          #    echo "apple\nBanana\ncat" > client.set
+          #    ${{ env.PSI_DIR }}/build/psi client.set --server ${{ env.PSI_DIR }}/build/datasets/fruits.set | grep -B 1 "apple"
 
       - name: Run Secure Query example
         run: |
@@ -231,7 +233,9 @@ jobs:
         run: ${{ env.LR_DIR }}/build/lr_test --compare --data lrtest_large | grep "All match!"
 
       - name: Build sample kernels
-        run: ./hekit build recipes/sample-kernels.toml
+        run: |
+          ./hekit build recipes/sample-kernels.toml
+          ./hekit list
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -20,12 +20,18 @@ env:
   SEAL_VER: 3.7.2
   PALISADE_VER: 1.11.6
   HELIB_VER: 2.2.1
-  HEXL_DIR: ~/.hekit/components/hexl/${HEXL_VER}/lib/cmake/hexl-${HEXL_VER}
-  SEAL_DIR: ~/.hekit/components/seal/v${SEAL_VER}/install/lib/cmake/SEAL-3.7
-  PALISADE_DIR: ~/.hekit/components/palisade/v${PALISADE_VER}/install/lib/Palisade
-  HELIB_DIR: ~/.hekit/components/helib/v${HELIB_VER}/share/cmake/helib
-  GSL_DIR: ~/.hekit/components/gsl/v3.1.0/install/share/cmake/Microsoft.GSL
-  ZSTD_DIR: ~/.hekit/components/zstd/v1.4.5/install/lib/cmake/zstd
+  HEKIT_DIR: ~/.hekit/components
+  HEXL_DIR: ${HEKIT_DIR}/hexl/${HEXL_VER}/lib/cmake/hexl-${HEXL_VER}
+  SEAL_DIR: ${HEKIT_DIR}/seal/v${SEAL_VER}/install/lib/cmake/SEAL-3.7
+  PALISADE_DIR: ${HEKIT_DIR}/palisade/v${PALISADE_VER}/install/lib/Palisade
+  HELIB_DIR: ${HEKIT_DIR}/helib/v${HELIB_VER}/share/cmake/helib
+  GSL_DIR: ${HEKIT_DIR}/gsl/v3.1.0/install/share/cmake/Microsoft.GSL
+  ZSTD_DIR: ${HEKIT_DIR}/zstd/v1.4.5/install/lib/cmake/zstd
+  PSI_DIR: ${HEKIT_DIR}/examples/psi
+  QUERY_DIR: ${HEKIT_DIR}/examples/secure-query
+  LR_DIR: ${HEKIT_DIR}/examples/logistic-regression
+  SEAL_KERNELS_DIR: ${HEKIT_DIR}/sample-kernels/seal
+  PALISADE_KERNELS_DIR: ${HEKIT_DIR/sample-kernels/palisade
 
 ################
 # Ubuntu 20.04 #
@@ -65,8 +71,7 @@ jobs:
         run: pytest tests/
 
   build-and-test-toolkit:
-    if: ${{ false }} # FIXME: Disable this job for now
-    name: Build, test and run components
+    name: Build, test and run HE Toolkit
     runs-on: ubuntu-20.04
     # Use environment protection (require review)
     environment: intel_workflow
@@ -90,64 +95,56 @@ jobs:
           ./hekit install recipes/default.toml
           ./hekit list
 
-      - name: Build and run PSI example
-        # TODO: Refactor to use hekit build recipes/examples.toml
+      # TODO: Remove this once there is !! substitution
+      - name: Modify paths in recipe files
         run: |
-          cd he-samples/examples/psi
-          cmake -S . -B build -Dhelib_DIR=${{ env.HELIB_DIR }}
-          cmake --build build -j
-          cd build
-          echo "apple\nBanana\ncat" > client.set
-          ./psi client.set | grep -B 1 "apple"
+          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1$GITHUB_WORKSPACE/g" recipes/examples.toml
+          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1$GITHUB_WORKSPACE/g" recipes/sample-kernels.toml
 
-      - name: Build and run Secure Query example
-        # TODO: Refactor to use hekit build recipes/examples.toml
+      - name: Build examples
+        run: ./hekit build recipes/examples.toml
+
+      - name: Run PSI example
         run: |
-          cd he-samples/examples/secure-query
-          cmake -S . -B build -DSEAL_DIR=${{ env.SEAL_DIR }} -DMicrosft.GSL_DIR=${{ env.GSL_DIR }} -Dzstd_DIR=${{ env.ZSTD_DIR }} -DHEXL_DIR=${{ env.HEXL_DIR }}
-          cmake --build build -j
-          cd build
+          echo "apple\nBanana\ncat" > client.set
+          ${{ env.PSI_DIR }}/build/psi client.set --server ${{ env.PSI_DIR }}/build/datasets/fruits.set | grep -B 1 "apple"
+
+      - name: Run Secure Query example
+        run: |
+          cd ${{ env.QUERY_DIR }}/build
           echo -n "Input: Louisiana, " && ./secure-query <<< $'\n\nLouisiana\n' | grep "Baton Rouge"
           echo -n "Input: North Dakota, " && ./secure-query <<< $'\n\nNorth Dakota\n' | grep "Bismarck"
           echo -n "Input: Wyoming, " && ./secure-query <<< $'\n\nWyoming\n' | grep "Cheyenne"
 
-      - name: Build and run LR example
-        # TODO: Refactor to use hekit build recipes/examples.toml
-        run: |
-          cd he-samples/examples/logistic-regression
-          cmake -S . -B build -DSEAL_DIR=${{ env.SEAL_DIR }} -DMicrosft.GSL_DIR=${{ env.GSL_DIR }} -Dzstd_DIR=${{ env.ZSTD_DIR }} -DHEXL_DIR=${{ env.HEXL_DIR }}
-          cmake --build build -j
-          cd build
-          ./lr_test --compare --data lrtest_large | grep "All match!"
+      - name: Run LR example
+        run: ${{ env.LR_DIR }}/build/lr_test --compare --data lrtest_large | grep "All match!"
 
       - name: Build sample kernels
-        # TODO: Refactor to use hekit build recipes/sample-kernels.toml
-        run: |
-          cd he-samples/sample-kernels
-          cmake -S . -B build -DENABLE_SEAL=ON -DENABLE_PALISADE=ON -DSEAL_DIR=${{ env.SEAL_DIR }} -DPalisade_DIR=${{ env.PALISADE_DIR }} -DMicrosft.GSL_DIR=${{ env.GSL_DIR }} -Dzstd_DIR=${{ env.ZSTD_DIR }} -DHEXL_DIR=${{ env.HEXL_DIR }}
-          cmake --build build -j
+        run: ./hekit build recipes/sample-kernels.toml
 
       - name: Run unit tests
-        run: ./he-samples/sample-kernels/build/test/unit-test
+        run: |
+          ${{ env.SEAL_KERNELS_DIR }}/build/test/unit-test
+          ${{ env.PALISADE_KERNELS_DIR }}/build test/unit-test
 
       # PALISADE sample kernels
       - name: Run PALISADE sample kernels
-        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ./he-samples/sample-kernels/build/sample-kernels-palisade --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-palisade_${GITHUB_SHA}.json"
+        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${{ env.PALISADE_KERNELS_DIR }}/build/sample-kernels-palisade --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-palisade_${GITHUB_SHA}.json"
       - name: Archive PALISADE sample kernel results
         uses: actions/upload-artifact@v2
         with:
           name: ${{github.job}}_sample-kernels-palisade_${{github.sha}}.json
-          path: he-samples/${{github.job}}_sample-kernels-palisade_${{github.sha}}.json
+          path: ${{github.job}}_sample-kernels-palisade_${{github.sha}}.json
           retention-days: 90 # Maximum for free version
 
       # SEAL sample kernels
       - name: Run SEAL sample kernels
-        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ./he-samples/sample-kernels/build/sample-kernels-seal --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-seal_${GITHUB_SHA}.json"
+        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${{ env.SEAL_KERNELS_DIR }}/build/sample-kernels-seal --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-seal_${GITHUB_SHA}.json"
       - name: Archive SEAL sample kernel results
         uses: actions/upload-artifact@v2
         with:
           name: ${{github.job}}_sample-kernels-seal_${{github.sha}}.json
-          path: he-samples/${{github.job}}_sample-kernels-seal_${{github.sha}}.json
+          path: ${{github.job}}_sample-kernels-seal_${{github.sha}}.json
           retention-days: 90 # Maximum for free version
 
 
@@ -184,8 +181,7 @@ jobs:
         run: pytest tests/
 
   build-and-test-toolkit-icelake:
-    if: ${{ false }} # FIXME: Disable this job for now
-    name: Build, test and run components (IceLake)
+    name: Build, test and run HE Toolkit (IceLake)
     runs-on: [self-hosted, Linux, X64, ice-lake]
     # Use environment protection (require review)
     environment: intel_workflow
@@ -208,72 +204,54 @@ jobs:
           ./hekit install recipes/default.toml
           ./hekit list
 
-      - name: Build and run PSI example
-        # TODO: Refactor to use hekit build recipes/examples.toml
+      # TODO: Remove this once there is !! substitution
+      - name: Modify paths in recipe files
         run: |
-          cd he-samples/examples/psi
-          cmake -S . -B build -Dhelib_DIR=${{ env.HELIB_DIR }}
-          cmake --build build -j
-          cd build
-          echo "apple\nBanana\ncat" > client.set
-          ./psi client.set | grep -B 1 "apple"
+          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1$GITHUB_WORKSPACE/g" recipes/examples.toml
+          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1$GITHUB_WORKSPACE/g" recipes/sample-kernels.toml
 
-      - name: Build and run Secure Query example
-        # TODO: Refactor to use hekit build recipes/examples.toml
+      - name: Build examples
+        run: ./hekit build recipes/examples.toml
+
+      - name: Run PSI example
         run: |
-          cd he-samples/examples/secure-query
-          cmake -S . -B build -DSEAL_DIR=${{ env.SEAL_DIR }} -DMicrosft.GSL_DIR=${{ env.GSL_DIR }} -Dzstd_DIR=${{ env.ZSTD_DIR }} -DHEXL_DIR=${{ env.HEXL_DIR }}
-          cmake --build build -j
-          cd build
+          echo "apple\nBanana\ncat" > client.set
+          ${{ env.PSI_DIR }}/build/psi client.set --server ${{ env.PSI_DIR }}/build/datasets/fruits.set | grep -B 1 "apple"
+
+      - name: Run Secure Query example
+        run: |
+          cd ${{ env.QUERY_DIR }}/build
           echo -n "Input: Louisiana, " && ./secure-query <<< $'\n\nLouisiana\n' | grep "Baton Rouge"
           echo -n "Input: North Dakota, " && ./secure-query <<< $'\n\nNorth Dakota\n' | grep "Bismarck"
           echo -n "Input: Wyoming, " && ./secure-query <<< $'\n\nWyoming\n' | grep "Cheyenne"
 
-      - name: Build and run LR example
-        # TODO: Refactor to use hekit build recipes/examples.toml
-        run: |
-          cd he-samples/examples/logistic-regression
-          cmake -S . -B build -DSEAL_DIR=${{ env.SEAL_DIR }} -DMicrosft.GSL_DIR=${{ env.GSL_DIR }} -Dzstd_DIR=${{ env.ZSTD_DIR }} -DHEXL_DIR=${{ env.HEXL_DIR }}
-          cmake --build build -j
-          cd build
-          ./lr_test --compare --data lrtest_large | grep "All match!"
+      - name: Run LR example
+        run: ${{ env.LR_DIR }}/build/lr_test --compare --data lrtest_large | grep "All match!"
 
       - name: Build sample kernels
-        # TODO: Refactor to use hekit build recipes/sample-kernels.toml
-        run: |
-          cd he-samples/sample-kernels
-          cmake -S . -B build -DENABLE_SEAL=ON -DENABLE_PALISADE=ON -DSEAL_DIR=${{ env.SEAL_DIR }} -DPalisade_DIR=${{ env.PALISADE_DIR }} -DMicrosft.GSL_DIR=${{ env.GSL_DIR }} -Dzstd_DIR=${{ env.ZSTD_DIR }} -DHEXL_DIR=${{ env.HEXL_DIR }}
-          cmake --build build -j
+        run: ./hekit build recipes/sample-kernels.toml
 
       - name: Run unit tests
-        run: ./he-samples/sample-kernels/build/test/unit-test
+        run: |
+          ${{ env.SEAL_KERNELS_DIR }}/build/test/unit-test
+          ${{ env.PALISADE_KERNELS_DIR }}/build test/unit-test
 
       # PALISADE sample kernels
       - name: Run PALISADE sample kernels
-        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ./he-samples/sample-kernels/build/sample-kernels-palisade --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-palisade_${GITHUB_SHA}.json"
+        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${{ env.PALISADE_KERNELS_DIR }}/build/sample-kernels-palisade --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-palisade_${GITHUB_SHA}.json"
       - name: Archive PALISADE sample kernel results
         uses: actions/upload-artifact@v2
         with:
           name: ${{github.job}}_sample-kernels-palisade_${{github.sha}}.json
-          path: he-samples/${{github.job}}_sample-kernels-palisade_${{github.sha}}.json
+          path: ${{github.job}}_sample-kernels-palisade_${{github.sha}}.json
           retention-days: 90 # Maximum for free version
 
       # SEAL sample kernels
       - name: Run SEAL sample kernels
-        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ./he-samples/sample-kernels/build/sample-kernels-seal --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-seal_${GITHUB_SHA}.json"
+        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${{ env.SEAL_KERNELS_DIR }}/build/sample-kernels-seal --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-seal_${GITHUB_SHA}.json"
       - name: Archive SEAL sample kernel results
         uses: actions/upload-artifact@v2
         with:
           name: ${{github.job}}_sample-kernels-seal_${{github.sha}}.json
-          path: he-samples/${{github.job}}_sample-kernels-seal_${{github.sha}}.json
+          path: ${{github.job}}_sample-kernels-seal_${{github.sha}}.json
           retention-days: 90 # Maximum for free version
-
-      - name: Remove components
-        run: |
-          ./hekit remove seal v${{ env.SEAL_VER }}
-          ./hekit remove gsl v3.1.0
-          ./hekit remove zstd v1.4.5
-          ./hekit remove helib v${{ env.HELIB_VER }}
-          ./hekit remove ntl 11.5.1
-          ./hekit remove palisade v${{ env.PALISADE_VER }}
-          ./hekit remove hexl ${{ env.HEXL_VER }}

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -212,13 +212,15 @@ jobs:
           ./hekit build recipes/examples.toml
           ./hekit list
           echo "PSI_BUILD_DIR=$HOME/.hekit/components/examples/psi/build" >> $GITHUB_ENV
-          echo "QUERY_BUILD_DIR=$HOME/.hekit/components/example/secure-query/build" >> $GITHUB_ENV
-          echo "LR_BUILD_DIR=$HOME/.hekit/components/example/logitic-regression/build" >> $GITHUB_ENV
+          echo "QUERY_BUILD_DIR=$HOME/.hekit/components/examples/secure-query/build" >> $GITHUB_ENV
+          echo "LR_BUILD_DIR=$HOME/.hekit/components/examples/logitic-regression/build" >> $GITHUB_ENV
 
       - name: Run PSI example
         run: |
-          echo -e "apple\nBanana\ncat" > client.set
+          echo -e "apple\nBanana\ncat\nRa\nCalifornia" > client.set
           ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/fruits.set | grep -B 1 "apple"
+          ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/ancient_egyptian_gods.set | grep -B 1 "Ra"
+          ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/us_states.set | grep -B 1 "California"
 
       - name: Run Secure Query example
         run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -98,8 +98,9 @@ jobs:
       # TODO: Remove this once there is !! substitution
       - name: Modify paths in recipe files
         run: |
-          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1$GITHUB_WORKSPACE/g" recipes/examples.toml
-          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1$GITHUB_WORKSPACE/g" recipes/sample-kernels.toml
+          echo ${GITHUB_WORKSPACE}
+          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1${GITHUB_WORKSPACE}/g" recipes/examples.toml
+          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1${GITHUB_WORKSPACE}/g" recipes/sample-kernels.toml
 
       - name: Build examples
         run: ./hekit build recipes/examples.toml
@@ -207,8 +208,8 @@ jobs:
       # TODO: Remove this once there is !! substitution
       - name: Modify paths in recipe files
         run: |
-          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1$GITHUB_WORKSPACE/g" recipes/examples.toml
-          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1$GITHUB_WORKSPACE/g" recipes/sample-kernels.toml
+          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1${GITHUB_WORKSPACE}/g" recipes/examples.toml
+          sed -i -e "s/\(src_dir = \"\)~\/git\/public-toolkit\/v2-prep\/he-toolkit/\1${GITHUB_WORKSPACE}/g" recipes/sample-kernels.toml
 
       - name: Build examples
         run: ./hekit build recipes/examples.toml

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -211,10 +211,10 @@ jobs:
         run: |
           ./hekit build recipes/examples.toml
           ./hekit list
-          echo "EXAMPLES_DIR=$HOME/.hekit/components/examples >> $GITHUB_ENV"
-          echo "PSI_BUILD_DIR=$EXAMPLES_DIR/psi/build >> $GITHUB_ENV"
-          echo "QUERY_BUILD_DIR=$EXAMPLES_DIR/secure-query/build >> $GITHUB_ENV"
-          echo "LR_BUILD_DIR=$EXAMPLES_DIR/logitic-regression/build >> $GITHUB_ENV"
+          echo "EXAMPLES_DIR=$HOME/.hekit/components/examples" >> $GITHUB_ENV
+          echo "PSI_BUILD_DIR=$EXAMPLES_DIR/psi/build" >> $GITHUB_ENV
+          echo "QUERY_BUILD_DIR=$EXAMPLES_DIR/secure-query/build" >> $GITHUB_ENV
+          echo "LR_BUILD_DIR=$EXAMPLES_DIR/logitic-regression/build" >> $GITHUB_ENV
 
       - name: Run PSI example
         run: |
@@ -235,9 +235,9 @@ jobs:
         run: |
           ./hekit build recipes/sample-kernels.toml
           ./hekit list
-          echo "KERNELS_DIR=$HOME/.hekit/components/sample-kernels >> $GITHUB_ENV"
-          echo "SEAL_KERNELS_BUILD_DIR=$KERNELS_DIR/seal/build >> $GITHUB_ENV"
-          echo "PALISADE_KERNELS_BUILD_DIR=$KERNELS_DIR/palisade/build >> $GITHUB_ENV"
+          echo "KERNELS_DIR=$HOME/.hekit/components/sample-kernels" >> $GITHUB_ENV
+          echo "SEAL_KERNELS_BUILD_DIR=$KERNELS_DIR/seal/build" >> $GITHUB_ENV
+          echo "PALISADE_KERNELS_BUILD_DIR=$KERNELS_DIR/palisade/build" >> $GITHUB_ENV
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -224,7 +224,8 @@ jobs:
 
       - name: Run Secure Query example
         run: |
-          cd ${{ env.QUERY_DIR }}/build
+          #cd ${{ env.QUERY_DIR }}/build
+          cd $HOME/.hekit/components/examples/secure-query/build
           echo -n "Input: Louisiana, " && ./secure-query <<< $'\n\nLouisiana\n' | grep "Baton Rouge"
           echo -n "Input: North Dakota, " && ./secure-query <<< $'\n\nNorth Dakota\n' | grep "Bismarck"
           echo -n "Input: Wyoming, " && ./secure-query <<< $'\n\nWyoming\n' | grep "Cheyenne"

--- a/recipes/default.toml
+++ b/recipes/default.toml
@@ -92,7 +92,6 @@ install = "cmake --install %init_install_dir%"
 # Dependencies
 ntl = "ntl/11.5.1"
 hexl = "hexl/1.2.3"
-ntl = "ntl/11.5.1"
 
 
 [[seal]]


### PR DESCRIPTION
Re-enabled the job "Build, test and run HE Toolkit" which builds the libraries and dependencies through hekit, builds and runs all example programs, and builds and runs the sample kernels and their tests.

**Note:** Only the Icelake build was enabled as the public CI runner currently has memory issues.