### PR TITLE
Tests for public CI runners

### DIFF
--- a/.github/hekit-recipes/helib.toml
+++ b/.github/hekit-recipes/helib.toml
@@ -70,6 +70,7 @@ pre-build = """cmake -S %src_dir% -B %init_build_dir%
                -Dhelib_DIR=$%helib%/export_cmake$"""
 build = "cmake --build %init_build_dir% -j"
 post-build = ""
+init_install_dir = ""
 install = ""
 # Dependencies
 helib = "helib/v2.2.1"

--- a/.github/hekit-recipes/helib.toml
+++ b/.github/hekit-recipes/helib.toml
@@ -1,0 +1,75 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+[[hexl]]
+skip = false
+version = "1.2.3"
+name = "1.2.3"
+fetch = "git clone https://github.com/intel/hexl.git --branch %version%"
+init_fetch_dir = "fetch"
+init_build_dir = "build"
+init_install_dir = "build"
+pre-build = """cmake -S %init_fetch_dir%/hexl -B %init_build_dir%
+               -DCMAKE_INSTALL_PREFIX=%export_install_dir%
+               -DHEXL_BENCHMARK=OFF
+               -DHEXL_TESTING=OFF"""
+build = "cmake --build %init_build_dir% -j"
+install = "cmake --install %init_install_dir%"
+export_install_dir = "install"
+export_cmake = "install/lib/cmake/hexl-%version%"
+
+
+[[ntl]]
+skip = false
+version = "11.5.1"
+name = "11.5.1"
+init_fetch_dir = "fetch"
+init_pre_build_dir = "build"
+init_build_dir = "build/ntl-%version%/src"
+init_install_dir = "build/ntl-%version%/src"
+fetch = "wget https://libntl.org/ntl-%version%.tar.gz"
+post-fetch = "bash -c 'tar -xvf %init_fetch_dir%/ntl-%version%.tar.gz -C %init_pre_build_dir%'"
+build = "bash -c './configure NTL_GMP_LIP=on NTL_THREADS=on NTL_THREAD_BOOST=on TUNE=generic PREFIX=%export_install_dir% && make -j'"
+install = "make install"
+export_install_dir = "install"
+
+
+[[helib]]
+skip = false
+version = "2.2.1"
+name = "v2.2.1"
+root = "%name%"
+init_fetch_dir = "fetch"
+init_build_dir = "build"
+init_install_dir = "build"
+export_install_dir = "install"
+fetch = "git clone https://github.com/homenc/HElib.git --branch %name%"
+pre-build = """cmake -S %init_fetch_dir%/HElib -B %init_build_dir%
+               -DCMAKE_INSTALL_PREFIX=%export_install_dir%
+               -DNTL_DIR=$%ntl%/export_install_dir$
+               -DUSE_INTEL_HEXL=ON
+               -DNTL_DIR=$%ntl%/export_install_dir$
+               -DHEXL_DIR=$%hexl%/export_cmake$"""
+build = "cmake --build %init_build_dir% -j"
+post-build = ""
+install = "cmake --install %init_install_dir%"
+export_cmake = "install/share/cmake/helib"
+# Dependencies
+ntl = "ntl/11.5.1"
+hexl = "hexl/1.2.3"
+
+
+[[examples]]
+skip = false
+name = "psi"
+fetch = ""
+init_fetch_dir = ""
+src_dir = "!toolkit-path!/he-samples/examples/psi"
+init_build_dir = "build"
+pre-build = """cmake -S %src_dir% -B %init_build_dir%
+               -Dhelib_DIR=$%helib%/export_cmake$"""
+build = "cmake --build %init_build_dir% -j"
+post-build = ""
+install = ""
+# Dependencies
+helib = "helib/v2.2.1"

--- a/.github/hekit-recipes/palisade.toml
+++ b/.github/hekit-recipes/palisade.toml
@@ -1,0 +1,64 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+[[hexl]]
+skip = false
+version = "1.2.3"
+name = "1.2.3"
+fetch = "git clone https://github.com/intel/hexl.git --branch %version%"
+init_fetch_dir = "fetch"
+init_build_dir = "build"
+init_install_dir = "build"
+pre-build = """cmake -S %init_fetch_dir%/hexl -B %init_build_dir%
+               -DCMAKE_INSTALL_PREFIX=%export_install_dir%
+               -DHEXL_BENCHMARK=OFF
+               -DHEXL_TESTING=OFF"""
+build = "cmake --build %init_build_dir% -j"
+install = "cmake --install %init_install_dir%"
+export_install_dir = "install"
+export_cmake = "install/lib/cmake/hexl-%version%"
+
+
+[[palisade]]
+skip = false
+version = "1.11.6"
+name = "v1.11.6"
+root = "%name%"
+init_fetch_dir = "fetch"
+init_build_dir = "build"
+init_install_dir = "build"
+export_install_dir = "install"
+fetch = "git clone https://gitlab.com/palisade/palisade-release.git --branch %name%"
+pre-build = """cmake -S %init_fetch_dir%/palisade-release -B %init_build_dir%
+               -DCMAKE_INSTALL_PREFIX=%export_install_dir%
+               -DBUILD_UNITTESTS=OFF
+               -DBUILD_EXAMPLES=OFF
+               -DBUILD_BENCHMARKS=OFF
+               -DWITH_INTEL_HEXL=ON
+               -DINTEL_HEXL_PREBUILT=ON
+               -DINTEL_HEXL_HINT_DIR=$%hexl%/export_cmake$"""
+build = "cmake --build %init_build_dir% -j"
+post-build = ""
+install = "cmake --install %init_install_dir%"
+export_cmake = "install/lib/Palisade"
+# Dependencies
+hexl = "hexl/1.2.3"
+
+
+[[sample-kernels]]
+skip = false
+name = "palisade"
+fetch = ""
+init_fetch_dir = ""
+src_dir = "!toolkit-path!/he-samples/sample-kernels"
+init_build_dir = "build"
+pre-build = """cmake -S %src_dir% -B %init_build_dir%
+               -DENABLE_PALISADE=ON
+               -DPalisade_DIR=$%palisade%/export_cmake$
+               -DHEXL_DIR=$%hexl%/export_cmake$"""
+build = "cmake --build %init_build_dir% -j"
+post-build = ""
+install = ""
+# Dependencies
+palisade = "palisade/v1.11.6"
+hexl = "hexl/1.2.3"

--- a/.github/hekit-recipes/palisade.toml
+++ b/.github/hekit-recipes/palisade.toml
@@ -58,6 +58,7 @@ pre-build = """cmake -S %src_dir% -B %init_build_dir%
                -DHEXL_DIR=$%hexl%/export_cmake$"""
 build = "cmake --build %init_build_dir% -j"
 post-build = ""
+init_install_dir = ""
 install = ""
 # Dependencies
 palisade = "palisade/v1.11.6"

--- a/.github/hekit-recipes/seal.toml
+++ b/.github/hekit-recipes/seal.toml
@@ -98,6 +98,7 @@ pre-build = """cmake -S %src_dir% -B %init_build_dir%
                -DHEXL_DIR=$%hexl%/export_cmake$"""
 build = "cmake --build %init_build_dir% -j"
 post-build = ""
+init_install_dir = ""
 install = ""
 # Dependencies
 seal = "seal/v3.7.2"
@@ -120,6 +121,7 @@ pre-build = """cmake -S %src_dir% -B %init_build_dir%
                -DHEXL_DIR=$%hexl%/export_cmake$"""
 build = "cmake --build %init_build_dir% -j"
 post-build = ""
+init_install_dir = ""
 install = ""
 # Dependencies
 seal = "seal/v3.7.2"
@@ -143,6 +145,7 @@ pre-build = """cmake -S %src_dir% -B %init_build_dir%
                -DHEXL_DIR=$%hexl%/export_cmake$"""
 build = "cmake --build %init_build_dir% -j"
 post-build = ""
+init_install_dir = ""
 install = ""
 # Dependencies
 seal = "seal/v3.7.2"

--- a/.github/hekit-recipes/seal.toml
+++ b/.github/hekit-recipes/seal.toml
@@ -1,0 +1,151 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+[[hexl]]
+skip = false
+version = "1.2.3"
+name = "1.2.3"
+fetch = "git clone https://github.com/intel/hexl.git --branch %version%"
+init_fetch_dir = "fetch"
+init_build_dir = "build"
+init_install_dir = "build"
+pre-build = """cmake -S %init_fetch_dir%/hexl -B %init_build_dir%
+               -DCMAKE_INSTALL_PREFIX=%export_install_dir%
+               -DHEXL_BENCHMARK=OFF
+               -DHEXL_TESTING=OFF"""
+build = "cmake --build %init_build_dir% -j"
+install = "cmake --install %init_install_dir%"
+export_install_dir = "install"
+export_cmake = "install/lib/cmake/hexl-%version%"
+
+
+[[gsl]]
+skip = false
+version = "3.1.0"
+name = "v3.1.0"
+fetch = "git clone https://github.com/microsoft/GSL.git --branch %name%"
+init_fetch_dir = "fetch"
+init_build_dir = "build"
+init_install_dir = "build"
+pre-build = """cmake -S %init_fetch_dir%/GSL -B %init_build_dir%
+               -DCMAKE_INSTALL_PREFIX=%export_install_dir%
+               -DGSL_TEST=OFF"""
+build = "cmake --build %init_build_dir% -j"
+install = "cmake --install %init_install_dir%"
+export_install_dir = "install"
+export_cmake = "install/share/cmake/Microsoft.GSL"
+
+
+[[zstd]]
+skip = false
+version = "1.4.5"
+name = "v1.4.5"
+fetch = "git clone https://github.com/facebook/zstd.git --branch %name%"
+init_fetch_dir = "fetch"
+init_build_dir = "build"
+init_install_dir = "build"
+pre-build = """cmake -S %init_fetch_dir%/zstd/build/cmake -B %init_build_dir%
+               -DCMAKE_INSTALL_PREFIX=%export_install_dir%
+               -DZSTD_BUILD_PROGRAMS=OFF
+               -DZSTD_BUILD_SHARED=OFF
+               -DZSTD_BUILD_STATIC=ON
+               -DZSTD_BUILD_TESTS=OFF
+               -DZSTD_MULTITHREAD_SUPPORT=OFF"""
+build = "cmake --build %init_build_dir% -j"
+install = "cmake --install %init_install_dir%"
+export_install_dir = "install"
+export_cmake = "install/lib/cmake/zstd"
+
+
+[[seal]]
+skip = false
+version = "3.7.2"
+name = "v3.7.2"
+root = "%name%"
+init_fetch_dir = "fetch"
+init_build_dir = "build"
+init_install_dir = "build"
+export_install_dir = "install"
+fetch = "git clone https://github.com/microsoft/SEAL.git --branch %name%"
+pre-build = """cmake -S %init_fetch_dir%/SEAL -B %init_build_dir%
+               -DCMAKE_INSTALL_PREFIX=%export_install_dir%
+               -DSEAL_BUILD_DEPS=OFF
+               -DSEAL_USE_INTEL_HEXL=ON
+               -DHEXL_DIR=$%hexl%/export_cmake$
+               -DMicrosoft.GSL_DIR=$%GSL%/export_cmake$
+               -Dzstd_DIR=$%zstd%/export_cmake$"""
+build = "cmake --build %init_build_dir% -j"
+post-build = ""
+install = "cmake --install %init_install_dir%"
+export_cmake = "install/lib/cmake/SEAL-3.7"
+# Dependencies
+hexl = "hexl/1.2.3"
+GSL = "gsl/v3.1.0"
+zstd = "zstd/v1.4.5"
+
+
+[[examples]]
+skip = false
+name = "logistic-regression"
+fetch = ""
+init_fetch_dir = ""
+src_dir = "!toolkit-path!/he-samples/examples/logistic-regression"
+init_build_dir = "build"
+pre-build = """cmake -S %src_dir% -B %init_build_dir%
+               -DSEAL_DIR=$%seal%/export_cmake$
+               -DMicrosoft.GSL_DIR=$%GSL%/export_cmake$
+               -Dzstd_DIR=$%zstd%/export_cmake$
+               -DHEXL_DIR=$%hexl%/export_cmake$"""
+build = "cmake --build %init_build_dir% -j"
+post-build = ""
+install = ""
+# Dependencies
+seal = "seal/v3.7.2"
+hexl = "hexl/1.2.3"
+GSL = "gsl/v3.1.0"
+zstd = "zstd/v1.4.5"
+
+
+[[examples]]
+skip = false
+name = "secure-query"
+fetch = ""
+init_fetch_dir = ""
+src_dir = "!toolkit-path!/he-samples/examples/secure-query"
+init_build_dir = "build"
+pre-build = """cmake -S %src_dir% -B %init_build_dir%
+               -DSEAL_DIR=$%seal%/export_cmake$
+               -DMicrosoft.GSL_DIR=$%GSL%/export_cmake$
+               -Dzstd_DIR=$%zstd%/export_cmake$
+               -DHEXL_DIR=$%hexl%/export_cmake$"""
+build = "cmake --build %init_build_dir% -j"
+post-build = ""
+install = ""
+# Dependencies
+seal = "seal/v3.7.2"
+hexl = "hexl/1.2.3"
+GSL = "gsl/v3.1.0"
+zstd = "zstd/v1.4.5"
+
+
+[[sample-kernels]]
+skip = false
+name = "seal"
+fetch = ""
+init_fetch_dir = ""
+src_dir = "!toolkit-path!/he-samples/sample-kernels"
+init_build_dir = "build"
+pre-build = """cmake -S %src_dir% -B %init_build_dir%
+               -DENABLE_SEAL=ON
+               -DSEAL_DIR=$%seal%/export_cmake$
+               -DMicrosoft.GSL_DIR=$%GSL%/export_cmake$
+               -Dzstd_DIR=$%zstd%/export_cmake$
+               -DHEXL_DIR=$%hexl%/export_cmake$"""
+build = "cmake --build %init_build_dir% -j"
+post-build = ""
+install = ""
+# Dependencies
+seal = "seal/v3.7.2"
+hexl = "hexl/1.2.3"
+GSL = "gsl/v3.1.0"
+zstd = "zstd/v1.4.5"

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -65,9 +65,8 @@ jobs:
       - name: Run pytests
         run: pytest tests/
 
-  build-and-test-toolkit:
-    if: ${{ false }} # FIXME: Disable this job for now
-    name: Build, test and run HE Toolkit
+  build-and-test-toolkit-palisade:
+    name: Build, test and run PALISADE dependent HE Toolkit
     runs-on: ubuntu-20.04
     # Use environment protection (require review)
     environment: intel_workflow
@@ -86,18 +85,50 @@ jobs:
           mkdir -p ~/.hekit
           cp default.config ~/.hekit/default.config
 
-      - name: Build and install default recipe
+      - name: Build and install PALISADE and sample kernels recipe
         run: |
-          ./hekit install recipes/default.toml
+          ./hekit install .github/hekit-recipes/palisade.toml --recipe_arg "toolkit-path=${GITHUB_WORKSPACE}"
           ./hekit list
+          echo "PALISADE_KERNELS_BUILD_DIR=$HOME/.hekit/components/sample-kernels/palisade/build" >> $GITHUB_ENV
 
-      - name: Build examples
+      - name: Run unit tests
+        run: ${PALISADE_KERNELS_BUILD_DIR}/test/unit-test
+
+      # PALISADE sample kernels
+      - name: Run PALISADE sample kernels
+        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${PALISADE_KERNELS_BUILD_DIR}/sample-kernels-palisade --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-palisade_${GITHUB_SHA}.json"
+      - name: Archive PALISADE sample kernel results
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{github.job}}_sample-kernels-palisade_${{github.sha}}.json
+          path: ${{github.job}}_sample-kernels-palisade_${{github.sha}}.json
+          retention-days: 90 # Maximum for free version
+
+  build-and-test-toolkit-helib:
+    name: Build, test and run HElib dependent HE Toolkit
+    runs-on: ubuntu-20.04
+    # Use environment protection (require review)
+    environment: intel_workflow
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
         run: |
-          ./hekit build recipes/examples.toml --recipe_arg "toolkit-path=${GITHUB_WORKSPACE}"
+          pip3 install toml
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Init hekit
+        run: |
+          mkdir -p ~/.hekit
+          cp default.config ~/.hekit/default.config
+
+      - name: Build and install HElib and example recipe
+        run: |
+          ./hekit install .github/hekit-recipes/helib.toml --recipe_arg "toolkit-path=${GITHUB_WORKSPACE}"
           ./hekit list
           echo "PSI_BUILD_DIR=$HOME/.hekit/components/examples/psi/build" >> $GITHUB_ENV
-          echo "QUERY_BUILD_DIR=$HOME/.hekit/components/examples/secure-query/build" >> $GITHUB_ENV
-          echo "LR_BUILD_DIR=$HOME/.hekit/components/examples/logistic-regression/build" >> $GITHUB_ENV
 
       - name: Run PSI example
         run: |
@@ -105,6 +136,34 @@ jobs:
           ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/fruits.set | grep -B 1 "apple"
           ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/ancient_egyptian_gods.set | grep -B 1 "Ba-Ra"
           ${PSI_BUILD_DIR}/psi client.set --server ${PSI_BUILD_DIR}/datasets/us_states.set | grep -B 1 "California"
+
+  build-and-test-toolkit-seal:
+    name: Build, test and run SEAL dependent HE Toolkit
+    runs-on: ubuntu-20.04
+    # Use environment protection (require review)
+    environment: intel_workflow
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        run: |
+          pip3 install toml
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Init hekit
+        run: |
+          mkdir -p ~/.hekit
+          cp default.config ~/.hekit/default.config
+
+      - name: Build and install SEAL, examples, and sample kernels recipe
+        run: |
+          ./hekit install .github/hekit-recipes/seal.toml --recipe_arg "toolkit-path=${GITHUB_WORKSPACE}"
+          ./hekit list
+          echo "QUERY_BUILD_DIR=$HOME/.hekit/components/examples/secure-query/build" >> $GITHUB_ENV
+          echo "LR_BUILD_DIR=$HOME/.hekit/components/examples/logistic-regression/build" >> $GITHUB_ENV
+          echo "SEAL_KERNELS_BUILD_DIR=$HOME/.hekit/components/sample-kernels/seal/build" >> $GITHUB_ENV
 
       - name: Run Secure Query example
         run: |
@@ -118,27 +177,8 @@ jobs:
           cd ${LR_BUILD_DIR}
           ./lr_test --compare --data lrtest_large | grep "All match!"
 
-      - name: Build sample kernels
-        run: |
-          ./hekit build recipes/sample-kernels.toml --recipe_arg "toolkit-path=${GITHUB_WORKSPACE}"
-          ./hekit list
-          echo "SEAL_KERNELS_BUILD_DIR=$HOME/.hekit/components/sample-kernels/seal/build" >> $GITHUB_ENV
-          echo "PALISADE_KERNELS_BUILD_DIR=$HOME/.hekit/components/sample-kernels/palisade/build" >> $GITHUB_ENV
-
       - name: Run unit tests
-        run: |
-          ${SEAL_KERNELS_BUILD_DIR}/test/unit-test
-          ${PALISADE_KERNELS_BUILD_DIR}/test/unit-test
-
-      # PALISADE sample kernels
-      - name: Run PALISADE sample kernels
-        run: KMP_WARNINGS=0 OMP_NUM_THREADS=5 ${PALISADE_KERNELS_BUILD_DIR}/sample-kernels-palisade --benchmark_out_format=json --benchmark_out="${GITHUB_JOB}_sample-kernels-palisade_${GITHUB_SHA}.json"
-      - name: Archive PALISADE sample kernel results
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{github.job}}_sample-kernels-palisade_${{github.sha}}.json
-          path: ${{github.job}}_sample-kernels-palisade_${{github.sha}}.json
-          retention-days: 90 # Maximum for free version
+        run: ${SEAL_KERNELS_BUILD_DIR}/test/unit-test
 
       # SEAL sample kernels
       - name: Run SEAL sample kernels


### PR DESCRIPTION
Toolkit unit, functional, and integration tests.
Public CI is split into 3 separate jobs: test PALISADE, test SEAL, test HElib.
These build the respective library and all dependent sample kernels and examples for that library.