### PR TITLE
Fixing docker dependency message

### DIFF
--- a/kit/command_docker_build.py
+++ b/kit/command_docker_build.py
@@ -11,8 +11,24 @@ from shutil import copyfile, rmtree
 from platform import system as os_name
 from typing import Dict, Iterable
 from archive import archive_and_compress
-from docker_tools import DockerTools, DockerException
 from constants import Constants
+
+try:
+    # docker-py is optional and will not be used from within a docker container
+    from docker_tools import DockerTools, DockerException
+except ImportError:
+
+    def try_setup_docker(args):  # pylint: disable=unused-argument
+        """Informs that this command can't be used due to missing dependencies"""
+        print("This command is disabled. To enable it install the docker-py dependency")
+        print("  pip install docker")
+
+
+else:
+
+    def try_setup_docker(args):
+        """Set up the docker environment"""
+        setup_docker(args)
 
 
 def copyfiles(files: Iterable[str], src_dir: str, dst_dir: str) -> None:
@@ -208,4 +224,4 @@ def set_docker_subparser(subparsers, hekit_root_dir):
     parser_docker_build.add_argument(
         "-y", action="store_false", help="say yes to prompts"
     )
-    parser_docker_build.set_defaults(fn=setup_docker, hekit_root_dir=hekit_root_dir)
+    parser_docker_build.set_defaults(fn=try_setup_docker, hekit_root_dir=hekit_root_dir)

--- a/kit/hekit.py
+++ b/kit/hekit.py
@@ -23,18 +23,9 @@ from command_remove import set_remove_subparser
 from command_list import set_list_subparser
 from command_install import set_install_subparser
 from command_check_deps import set_check_dep_subparser
+from command_docker_build import set_docker_subparser
 from tools.healg import healg, set_gen_primes, set_gen_algebras
 from constants import Constants
-
-try:
-    # docker-py is optional and will not be used from within a docker container
-    from command_docker_build import set_docker_subparser
-except ImportError:
-
-    def set_docker_subparser(arg1, arg2):  # pylint: disable=unused-argument
-        """Informs that this command can't be used due to missing dependencies"""
-        print("This command is disabled. To enable it install the docker-py dependency")
-        print("  pip install docker")
 
 
 def parse_cmdline():


### PR DESCRIPTION
The previous implementation was wrong because the error message was printed when others commands were executed. This bug was fixed.