### PR TITLE
Enabling openMP for Clang

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -37,6 +37,7 @@ RUN apt update && \
                    htop                           \
                    jq                             \
                    libgmp-dev                     \
+                   libomp-dev                     \
                    libterm-readline-gnu-perl      \
                    m4                             \
                    man                            \


### PR DESCRIPTION
 When building the HE-Toolkit with Clang 10 errors occur at least (but limited to), logistic regression example and secure query example. The required library was added to fix this issue.