### PR TITLE
Fix bug with minimum column width in list cmd

### DIFF
--- a/kit/commands/list_cmd.py
+++ b/kit/commands/list_cmd.py
@@ -13,6 +13,8 @@ from kit.utils.typing import PathType
 
 # Number of separation spaces for columns
 _SEP_SPACES = 2
+_HEADER_COL_1 = "COMPONENT"
+_HEADER_COL_2 = "INSTANCE"
 
 
 class RepoProperties:
@@ -24,10 +26,11 @@ class RepoProperties:
         self._repo_structure = RepoProperties._repo_struct(repo_location)
 
         # Get the width of the widest component
-        self.width_comp = self.max_len(self._repo_structure.keys())
+        all_components = [*self._repo_structure.keys(), _HEADER_COL_1]
+        self.width_comp = self.max_len(all_components)
 
         # Get the width of the widest instance
-        all_instances = self._repo_structure.values()
+        all_instances = [*self._repo_structure.values(), [_HEADER_COL_2]]
         self.width_inst = self.max_len(chain.from_iterable(all_instances))
 
         # Include column separation
@@ -67,7 +70,7 @@ def list_components(args):
 
     # Header
     print(
-        f"{'COMPONENT':{width_comp}} {'INSTANCE':{width_inst}} {'FETCH':{width_status}} {'BUILD':{width_status}} {'INSTALL':{width_status}}"
+        f"{_HEADER_COL_1:{width_comp}} {_HEADER_COL_2:{width_inst}} {'FETCH':{width_status}} {'BUILD':{width_status}} {'INSTALL':{width_status}}"
     )
 
     for comp_name, inst_list in repo_properties.structure.items():

--- a/tests/test_cmd_list.py
+++ b/tests/test_cmd_list.py
@@ -7,7 +7,7 @@ from kit.commands.list_cmd import list_components, RepoProperties, _SEP_SPACES
 
 
 def test_get_repo_properties_max_width(mocker):
-    exp_comps = ["1234567", "123", "12345678"]
+    exp_comps = ["1234567", "123", "123456789"]
     exp_inst1 = ["123"]
     exp_inst2 = ["1", "1234567890123456"]
     exp_inst3 = ["123456"]
@@ -18,7 +18,7 @@ def test_get_repo_properties_max_width(mocker):
         exp_comps[1]: exp_inst2,
         exp_comps[2]: exp_inst3,
     }
-    exp_width_comp = 8 + _SEP_SPACES
+    exp_width_comp = 9 + _SEP_SPACES
     exp_width_inst = 16 + _SEP_SPACES
 
     act_props = RepoProperties("")
@@ -34,7 +34,7 @@ def test_get_repo_properties_without_instances(mocker):
     mock_list_dirs.side_effect = [exp_comps, exp_inst1]
     exp_repo_structure = {exp_comps[0]: exp_inst1}
     exp_width_comp = 20 + _SEP_SPACES
-    exp_width_inst = 0 + _SEP_SPACES
+    exp_width_inst = 8 + _SEP_SPACES
 
     act_props = RepoProperties("")
     assert act_props.structure == exp_repo_structure
@@ -48,8 +48,8 @@ def test_get_repo_properties_without_components(mocker):
     mock_list_dirs = mocker.patch("kit.commands.list_cmd.list_dirs")
     mock_list_dirs.side_effect = [exp_comps, exp_inst1]
     exp_repo_structure = {}
-    exp_width_comp = 0 + _SEP_SPACES
-    exp_width_inst = 0 + _SEP_SPACES
+    exp_width_comp = 9 + _SEP_SPACES
+    exp_width_inst = 8 + _SEP_SPACES
 
     act_props = RepoProperties("")
     assert act_props.structure == exp_repo_structure
@@ -302,8 +302,13 @@ def install_failure():
 
 def get_width_and_header(comp_name, comp_inst, separation_spaces=_SEP_SPACES):
     width = 10
-    width_comp = len(comp_name) + separation_spaces
-    width_inst = len(comp_inst) + separation_spaces
+
+    width_comp = (
+        len(comp_name) if len(comp_name) > len("component") else len("component")
+    )
+    width_comp += separation_spaces
+    width_inst = len(comp_inst) if len(comp_inst) > len("instance") else len("instance")
+    width_inst += separation_spaces
     return width, f"{comp_name:{width_comp}} {comp_inst:{width_inst}}"
 
 

--- a/tests/test_integration_install.py
+++ b/tests/test_integration_install.py
@@ -27,7 +27,7 @@ def test_cmds_install_list_remove(tmp_path, hekit_path, input_files_path):
     cmd = f"{hekit_path} --config {config_file} list"
     act_result = execute_process(cmd)
     assert (
-        f"{component}   {instance}   success                         "
+        f"{component}        {instance}      success                        "
         in act_result.stdout
     )
     assert not act_result.stderr
@@ -44,7 +44,7 @@ def test_cmds_install_list_remove(tmp_path, hekit_path, input_files_path):
     cmd = f"{hekit_path} --config {config_file} list"
     act_result = execute_process(cmd)
     assert (
-        f"{component}   {instance}   success    success              "
+        f"{component}        {instance}      success    success              "
         in act_result.stdout
     )
     assert not act_result.stderr
@@ -61,7 +61,7 @@ def test_cmds_install_list_remove(tmp_path, hekit_path, input_files_path):
     cmd = f"{hekit_path} --config {config_file} list"
     act_result = execute_process(cmd)
     assert (
-        f"{component}   {instance}   success    success    success   "
+        f"{component}        {instance}      success    success    success   "
         in act_result.stdout
     )
     assert not act_result.stderr


### PR DESCRIPTION
Bug: When all items are smaller than the width of the column header it causes the output to become misaligned.