### PR TITLE
PSI IO use streams for Kafka connection

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Build PSI config tests
         run: |
-          ./hekit --config default.config install recipes/config-psi.toml --recipe_arg "toolkit-path=${GITHUB_WORKSPACE}"
+          ./hekit --config default.config install recipes/kafka-config-psi.toml --recipe_arg "toolkit-path=${GITHUB_WORKSPACE}"
           ./hekit --config default.config list
           echo "CONFIG_PSI_TEST_DIR=$HOME/.hekit/components/psi/configurable-psi/build" >> $GITHUB_ENV
 
@@ -348,7 +348,7 @@ jobs:
 
       - name: Build PSI config tests
         run: |
-          ./hekit --config $CONFIG_FILE install recipes/config-psi.toml --recipe_arg "toolkit-path=${GITHUB_WORKSPACE}"
+          ./hekit --config $CONFIG_FILE install recipes/kafka-config-psi.toml --recipe_arg "toolkit-path=${GITHUB_WORKSPACE}"
           ./hekit --config $CONFIG_FILE list
           echo "CONFIG_PSI_TEST_DIR=$HOME/.hekit/components/psi/configurable-psi/build" >> $GITHUB_ENV
 

--- a/deployments/config_psi/psi/include/data_connection.h
+++ b/deployments/config_psi/psi/include/data_connection.h
@@ -198,7 +198,6 @@ class KafkaConn : public DataConn {
   std::unique_ptr<DataRecord> read() const override {
     auto records = consumer_ptr_->poll(std::chrono::milliseconds(1000));
     if (records.size() == 0) {
-      // std::cout << "No record found.\n";
       return nullptr;
     }
     if (records.size() > 1) {
@@ -239,10 +238,6 @@ class KafkaConn : public DataConn {
     // Create out topic
     std::ostringstream out_topic;
     out_topic << bank_id << "." << user_id << "." << job_id;
-
-    // return std::make_unique<FileRecord>(
-    // datafilepath, config_.mode(), Metadata{{"out-topic", out_topic.str()}},
-    // metadata_filepath);
 
     // Create kakfa record and write data to record
     auto kafka_record = std::make_unique<KafkaRecord>(

--- a/deployments/config_psi/psi/include/data_connection.h
+++ b/deployments/config_psi/psi/include/data_connection.h
@@ -240,9 +240,18 @@ class KafkaConn : public DataConn {
     std::ostringstream out_topic;
     out_topic << bank_id << "." << user_id << "." << job_id;
 
-    return std::make_unique<FileRecord>(
-        datafilepath, config_.mode(), Metadata{{"out-topic", out_topic.str()}},
-        metadata_filepath);
+    // return std::make_unique<FileRecord>(
+    // datafilepath, config_.mode(), Metadata{{"out-topic", out_topic.str()}},
+    // metadata_filepath);
+
+    // Create kakfa record and write data to record
+    auto kafka_record = std::make_unique<KafkaRecord>(
+        Metadata{{"out-topic", out_topic.str()},
+                 {"heql", fixNewline(find("HEQL", record))}});
+    kafka_record->write(
+        const_cast<char*>(reinterpret_cast<const char*>(record.value().data())),
+        record.value().size());
+    return kafka_record;
   }
 
   void write(DataRecord& data) const override {

--- a/deployments/config_psi/psi/include/data_record.h
+++ b/deployments/config_psi/psi/include/data_record.h
@@ -98,8 +98,10 @@ class KafkaRecord : public DataRecord {
  public:
   KafkaRecord(const Metadata& metadata) : metadata_(metadata) {}
 
-  // Not implementing this for now
-  void read(char* data, size_t size) override {}
+  void read(char* data, size_t size) override {
+    data = buffer_.data();
+    size = buffer_.size();
+  }
 
   void write(char* data, size_t size) override {
     buffer_ = std::vector<char>{data, data + size};

--- a/deployments/config_psi/psi/include/read_config.h
+++ b/deployments/config_psi/psi/include/read_config.h
@@ -3,6 +3,7 @@
  */
 
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <nlohmann/json.hpp>
 
@@ -107,6 +108,10 @@ void loadConfigFile(CmdLineOpts& options) {
     options.outConnType = Type::FILESYS;
   } else if (out_type == "kafka") {
     options.outConnType = Type::KAFKA;
+  } else {
+    std::stringstream msg;
+    msg << "Unknown output data source type '" << out_type << "'";
+    throw std::runtime_error(msg.str());
   }
 
   auto query_type = config.at("query").at("data_source").get<std::string>();
@@ -114,5 +119,9 @@ void loadConfigFile(CmdLineOpts& options) {
     options.queryConnType = Type::FILESYS;
   } else if (query_type == "kafka") {
     options.queryConnType = Type::KAFKA;
+  } else {
+    std::stringstream msg;
+    msg << "Unknown query data source type '" << out_type << "'";
+    throw std::runtime_error(msg.str());
   }
 }

--- a/recipes/kafka-config-psi.toml
+++ b/recipes/kafka-config-psi.toml
@@ -98,7 +98,6 @@ pre-build = """cmake -S %src_dir% -B %init_build_dir%
                -DKAFKA_DIR=$%librdkafka%/export_install_dir$
                -DJSON_DIR=$%json%/export_fetch$/single_include
                -DENABLE_TESTS=ON
-               -DCMAKE_BUILD_TYPE=Debug
                -DGTest_DIR=$%gtest%/export_cmake$"""
 build = "cmake --build %init_build_dir% -j"
 # Dependencies

--- a/recipes/kafka-config-psi.toml
+++ b/recipes/kafka-config-psi.toml
@@ -27,8 +27,8 @@ install = "make install"
 
 
 [[helib]]
-version = "master"
-name = "psi-io"
+version = "streamio"
+name = "psi-io-streamio"
 root = "%name%"
 export_install_dir = "install"
 fetch = "git clone https://github.com/helibproject/HElib.git --branch %version%"
@@ -98,10 +98,11 @@ pre-build = """cmake -S %src_dir% -B %init_build_dir%
                -DKAFKA_DIR=$%librdkafka%/export_install_dir$
                -DJSON_DIR=$%json%/export_fetch$/single_include
                -DENABLE_TESTS=ON
+               -DCMAKE_BUILD_TYPE=Debug
                -DGTest_DIR=$%gtest%/export_cmake$"""
 build = "cmake --build %init_build_dir% -j"
 # Dependencies
-helib = "helib/psi-io"
+helib = "helib/psi-io-streamio"
 gtest = "gtest/v1.12.1"
 json = "json/nlohmann-json"
 kafka = "modern-cpp-kafka/v2022.10.12"

--- a/recipes/kafka-config-psi.toml
+++ b/recipes/kafka-config-psi.toml
@@ -28,7 +28,7 @@ install = "make install"
 
 [[helib]]
 version = "streamio"
-name = "psi-io-streamio"
+name = "psi-io"
 root = "%name%"
 export_install_dir = "install"
 fetch = "git clone https://github.com/helibproject/HElib.git --branch %version%"
@@ -102,7 +102,7 @@ pre-build = """cmake -S %src_dir% -B %init_build_dir%
                -DGTest_DIR=$%gtest%/export_cmake$"""
 build = "cmake --build %init_build_dir% -j"
 # Dependencies
-helib = "helib/psi-io-streamio"
+helib = "helib/psi-io"
 gtest = "gtest/v1.12.1"
 json = "json/nlohmann-json"
 kafka = "modern-cpp-kafka/v2022.10.12"


### PR DESCRIPTION
Streams are now used for reading in data from Kafka instead of serialising to disk first.