### PR TITLE
Deprecate testing on ubuntu20.04

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,52 +1,14 @@
 # CI Notes
 
-CI runs with Python 3.8, 3.9 on Ubuntu 20.04
 CI runs with Python 3.10 on Ubuntu 22.04
 
+Check the [github-ci.yml](./github-ci.yml) for the versions of the tooling used.
+
 ## Compilers tested
-### Ubuntu 20.04
-
-|              | HELIB | SEAL |
-|:------------:|:-----:|:----:|
-| **clang-10** |  Pass | Pass |
-|  **gcc-10**  |  Pass | Pass |
-
-</br>
 
 ### Ubuntu 22.04
 |              | HELIB |  SEAL |
 |:------------:|:-----:|:-----:|
-| **clang-12** |  Pass | Fail* |
 | **clang-14** |  Pass |  Pass |
-|  **gcc-10**  |  Pass |  Pass |
 |  **gcc-11**  |  Pass |  Pass |
 
-\* Under investigation
-
-</br>
-
-## Known compatibility issues
-
-### Ubuntu 20.04
-Clang-13 and clang-14 not available on Ubuntu 20.04 LTS
-|              | HELib |  SEAL |
-|:------------:|:-----:|:-----:|
-| **clang-10** |  Pass |  Pass |
-| **clang-11** |  Pass |  Pass |
-| **clang-12** |  Pass | Fail* |
-
-\* Under investigation
-
-</br>
-
-### Ubuntu 22.04
-
-Ubuntu 22.04 no longer supports clang-10
-|              | HELIB |  SEAL |
-|:------------:|:-----:|:-----:|
-| **clang-11** |  Pass |  Pass |
-| **clang-12** |  Pass | Fail* |
-| **clang-13** |  Pass | Fail* |
-| **clang-14** |  Pass |  Pass |
-
-\* Under investigation

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,4 +11,3 @@ Check the [github-ci.yml](./github-ci.yml) for the versions of the tooling used.
 |:------------:|:-----:|:-----:|
 | **clang-14** |  Pass |  Pass |
 |  **gcc-11**  |  Pass |  Pass |
-

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # Required for pre-commit
-      - run: pip3 install bandit black cpplint docker mypy pydantic==2 pylint pylint-pydantic types-toml
+      - run: pip3 install bandit black cpplint docker mypy==0.991 pydantic==2 pylint pylint-pydantic types-toml
       - run: sudo snap install shfmt
       - run: sudo apt install shellcheck
       # NOTE: This is deprecated in favor of pre-commit.ci

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -344,6 +344,8 @@ jobs:
 ##############
   format-icelake:
     name: Format (IceLake)
+    # Disable this job for now and until a self-hosted icelake becomes available
+    if: ${{ false }}
     runs-on: [self-hosted, Linux, X64, ice-lake]
     steps:
       # Add local bin for cpplint
@@ -355,6 +357,8 @@ jobs:
 
   test-hekit-icelake:
     name: Test hekit commands (IceLake)
+    # Disable this job for now and until a self-hosted icelake becomes available
+    if: ${{ false }}
     runs-on: [self-hosted, Linux, X64, ice-lake]
     defaults:
       run:
@@ -369,6 +373,8 @@ jobs:
 
   build-and-test-toolkit-icelake:
     name: Build, test and run HE Toolkit (IceLake)
+    # Disable this job for now and until a self-hosted icelake becomes available
+    if: ${{ false }}
     runs-on: [self-hosted, Linux, X64, ice-lake]
     defaults:
       run:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # Required for pre-commit
-      - run: pip3 install bandit black cpplint docker mypy==0.991 pydantic==2 pylint pylint-pydantic types-toml
+      - run: pip3 install bandit black cpplint docker mypy pydantic==2 pylint pylint-pydantic types-toml
       - run: sudo snap install shfmt
       - run: sudo apt install shellcheck
       # NOTE: This is deprecated in favor of pre-commit.ci

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # Required for pre-commit
-      - run: pip3 install bandit black cpplint docker mypy pydantic pylint pylint-pydantic types-toml
+      - run: pip3 install bandit black cpplint docker mypy pydantic==2 pylint pylint-pydantic types-toml
       - run: sudo snap install shfmt
       - run: sudo apt install shellcheck
       # NOTE: This is deprecated in favor of pre-commit.ci

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # Required for pre-commit
-      - run: pip3 install bandit black cpplint docker mypy pydantic==2 pylint pylint-pydantic types-toml
+      - run: pip3 install bandit black cpplint docker mypy pydantic==1.10.4 pylint pylint-pydantic types-toml
       - run: sudo snap install shfmt
       - run: sudo apt install shellcheck
       # NOTE: This is deprecated in favor of pre-commit.ci
@@ -168,7 +168,7 @@ jobs:
 
       - name: Setup
         run: |
-          pip3 install toml pydantic==2 pytest
+          pip3 install toml pydantic==1.10.4 pytest
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "CC=${{matrix.c_compiler}}" >> $GITHUB_ENV
           echo "CXX=${{matrix.cxx_compiler}}" >> $GITHUB_ENV

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Setup
         run: |
-          pip3 install toml pydantic pytest
+          pip3 install toml pydantic==2 pytest
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "CC=${{matrix.c_compiler}}" >> $GITHUB_ENV
           echo "CXX=${{matrix.cxx_compiler}}" >> $GITHUB_ENV

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -16,12 +16,12 @@ on:
   workflow_dispatch:
 
 ################
-# Ubuntu 20.04 #
+# Ubuntu 22.04 #
 ################
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # Required for pre-commit
@@ -35,7 +35,7 @@ jobs:
 
   test-hekit-bash:
     name: Test hekit commands (bash)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
@@ -58,7 +58,7 @@ jobs:
 
   test-hekit-zshell:
     name: Test hekit commands (zshell)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
@@ -94,38 +94,18 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-        c_compiler: [clang-10, clang-14, gcc-10, gcc-11]
-        os: [ubuntu-20.04, ubuntu-22.04]
+        # python3.10 is default on Ubuntu-22.04
+        python-version: ["3.10"]
+        c_compiler: [clang-14, gcc-11]
+        os: [ubuntu-22.04]
         include:
           # pairing cc compiler with relevant cxx compiler
-          - c_compiler: clang-10
-            cxx_compiler: clang++-10
+          # clang-14 and gcc-11 default on Ubuntu-22.04
           - c_compiler: clang-14
             cxx_compiler: clang++-14
-          - c_compiler: gcc-10
-            cxx_compiler: g++-10
           - c_compiler: gcc-11
             cxx_compiler: g++-11
-        exclude:
-          # clang-14 and gcc-11 not supported on ubuntu-20.04
-          - os: ubuntu-20.04
-            c_compiler: clang-14
-          - os: ubuntu-20.04
-            c_compiler: gcc-11
-          # clang-14 and gcc-11 default on Ubuntu-22.04
-          - os: ubuntu-22.04
-            c_compiler: clang-10
-          - os: ubuntu-22.04
-            c_compiler: gcc-10
-          # python3.10 is default on Ubuntu-22.04
-          - os: ubuntu-22.04
-            python-version: "3.8"
-          - os: ubuntu-22.04
-            python-version: "3.9"
-          # python3.8 is default on Ubuntu-20.04
-          - os: ubuntu-20.04
-            python-version: "3.10"
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -167,38 +147,17 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-        c_compiler: [clang-10, clang-14, gcc-10, gcc-11]
-        os: [ubuntu-20.04, ubuntu-22.04]
+        # python3.10 is default on Ubuntu-22.04
+        python-version: ["3.10"]
+        c_compiler: [clang-14, gcc-11]
+        os: [ubuntu-22.04]
         include:
           # pairing cc compiler with relevant cxx compiler
-          - c_compiler: clang-10
-            cxx_compiler: clang++-10
+          # clang-14 and gcc-11 default on Ubuntu-22.04
           - c_compiler: clang-14
             cxx_compiler: clang++-14
-          - c_compiler: gcc-10
-            cxx_compiler: g++-10
           - c_compiler: gcc-11
             cxx_compiler: g++-11
-        exclude:
-          # clang-14 and gcc-11 not supported on ubuntu-20.04
-          - os: ubuntu-20.04
-            c_compiler: clang-14
-          - os: ubuntu-20.04
-            c_compiler: gcc-11
-          # clang-14 and gcc-11 default on Ubuntu-22.04
-          - os: ubuntu-22.04
-            c_compiler: clang-10
-          - os: ubuntu-22.04
-            c_compiler: gcc-10
-          # python3.10 is default on Ubuntu-22.04
-          - os: ubuntu-22.04
-            python-version: "3.8"
-          - os: ubuntu-22.04
-            python-version: "3.9"
-          # python3.8 is default on Ubuntu-20.04
-          - os: ubuntu-20.04
-            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v3
@@ -252,38 +211,17 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-        c_compiler: [clang-10, clang-14, gcc-10, gcc-11]
-        os: [ubuntu-20.04, ubuntu-22.04]
+        # python3.10 is default on Ubuntu-22.04
+        python-version: ["3.10"]
+        c_compiler: [clang-14, gcc-11]
+        os: [ubuntu-22.04]
         include:
           # pairing cc compiler with relevant cxx compiler
-          - c_compiler: clang-10
-            cxx_compiler: clang++-10
+          # clang-14 and gcc-11 default on Ubuntu-22.04
           - c_compiler: clang-14
             cxx_compiler: clang++-14
-          - c_compiler: gcc-10
-            cxx_compiler: g++-10
           - c_compiler: gcc-11
             cxx_compiler: g++-11
-        exclude:
-          # clang-14 and gcc-11 not supported on ubuntu-20.04
-          - os: ubuntu-20.04
-            c_compiler: clang-14
-          - os: ubuntu-20.04
-            c_compiler: gcc-11
-          # clang-14 and gcc-11 default on Ubuntu-22.04
-          - os: ubuntu-22.04
-            c_compiler: clang-10
-          - os: ubuntu-22.04
-            c_compiler: gcc-10
-          # python3.10 is default on Ubuntu-22.04
-          - os: ubuntu-22.04
-            python-version: "3.8"
-          - os: ubuntu-22.04
-            python-version: "3.9"
-          # python3.8 is default on Ubuntu-20.04
-          - os: ubuntu-20.04
-            python-version: "3.10"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC2269 # Disable SC2269 (info): This variable is assigned to itself, so the assignment does nothing.

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,1 +1,2 @@
 disable=SC2269 # Disable SC2269 (info): This variable is assigned to itself, so the assignment does nothing.
+disable=SC2294 (warning): eval negates the benefit of arrays. Drop eval to preserve whitespace/symbols (or eval as string).

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default codeowner for all files
-* @intel/he-toolkit-maintain
+# * @intel/he-toolkit-maintain
+* @faberga @kylanerace @jobottle @hamishun @jlhcrawford @skmono @bahattin56
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,3 @@
 # Default codeowner for all files
 # * @intel/he-toolkit-maintain
 * @faberga @kylanerace @jobottle @hamishun @jlhcrawford @skmono @bahattin56
-

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ g++ == 11.x or clang == 14.x
 pthread
 virtualenv (optional if building the Logistic Regression Example)
 autoconf   (optional if using PALISADE)
-gmp 1.5.x  (optional if using HElib)
+gmp == 1.5.x  (optional if using HElib)
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ additionally install the following system dependencies,
 m4
 patchelf
 cmake >= 3.13
-g++ = 11.x or clang = 14.x
+g++ == 11.x or clang == 14.x
 pthread
 virtualenv (optional if building the Logistic Regression Example)
 autoconf   (optional if using PALISADE)

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Want to get up and running quickly with Intel HE toolkit? Then follow our
 [Quick Start guide](QUICK_START.md).
 
 ## Dependencies
-Intel HE toolkit has been tested on Ubuntu 20.04
+Intel HE toolkit has been tested on Ubuntu 22.04
 
 Must have system dependencies for the toolkit include,
 ```
-python >= 3.8
+python >= 3.10
 pip
 git
 ```
@@ -81,11 +81,11 @@ additionally install the following system dependencies,
 m4
 patchelf
 cmake >= 3.13
-g++ >= 10.0 or clang >= 10.0
+g++ = 11.x or clang = 14.x
 pthread
 virtualenv (optional if building the Logistic Regression Example)
 autoconf   (optional if using PALISADE)
-gmp        (optional if using HElib)
+gmp 1.5.x  (optional if using HElib)
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ additionally install the following system dependencies,
 ```
 m4
 patchelf
-cmake >= 3.13
+cmake >= 3.22
 g++ == 11.x or clang == 14.x
 pthread
 virtualenv (optional if building the Logistic Regression Example)

--- a/docker/runners.sh
+++ b/docker/runners.sh
@@ -8,7 +8,7 @@ HEKIT_SAMPLE_KERNELS="$HEKIT_DIR/sample-kernels"
 __run_cmd() {
   (
     set -e
-    eval "$*"
+    eval "$@"
   )
 }
 
@@ -16,12 +16,12 @@ run_lr_example() {
   (
     set -e
     cd "$HEKIT_EXAMPLES/logistic-regression/build"
-    OMP_NUM_THREADS="$(nproc)" ./lr_test "$*"
+    OMP_NUM_THREADS="$(nproc)" ./lr_test "$@"
   )
 }
 
 run_psi_example() {
-  __run_cmd "$HEKIT_EXAMPLES"/psi/build/psi --server "$HEKIT_EXAMPLES"/psi/build/datasets/fruits.set "$*"
+  __run_cmd "$HEKIT_EXAMPLES"/psi/build/psi --server "$HEKIT_EXAMPLES"/psi/build/datasets/fruits.set "$@"
 }
 
 run_query_example() {

--- a/docker/runners.sh
+++ b/docker/runners.sh
@@ -8,7 +8,7 @@ HEKIT_SAMPLE_KERNELS="$HEKIT_DIR/sample-kernels"
 __run_cmd() {
   (
     set -e
-    eval "$@"
+    eval "$*"
   )
 }
 
@@ -16,12 +16,12 @@ run_lr_example() {
   (
     set -e
     cd "$HEKIT_EXAMPLES/logistic-regression/build"
-    OMP_NUM_THREADS="$(nproc)" ./lr_test "$@"
+    OMP_NUM_THREADS="$(nproc)" ./lr_test "$*"
   )
 }
 
 run_psi_example() {
-  __run_cmd "$HEKIT_EXAMPLES"/psi/build/psi --server "$HEKIT_EXAMPLES"/psi/build/datasets/fruits.set "$@"
+  __run_cmd "$HEKIT_EXAMPLES"/psi/build/psi --server "$HEKIT_EXAMPLES"/psi/build/datasets/fruits.set "$*"
 }
 
 run_query_example() {

--- a/docker/which-files.txt
+++ b/docker/which-files.txt
@@ -15,6 +15,7 @@
 .gitignore
 .pre-commit-config.yaml
 .pylintrc
+.shellcheckrc
 .typos.toml
 CODEOWNERS
 CODE_OF_CONDUCT.md

--- a/kit/utils/tab_completion.py
+++ b/kit/utils/tab_completion.py
@@ -50,7 +50,6 @@ def get_plugins_by_state(
 ) -> List[str]:
     """Return a list of plugins with a specific state"""
     try:
-
         plugin_dict = load_toml(source_file)[PluginsConfig.KEY]
         return [k for k, v in plugin_dict.items() if v["state"] == state]
 

--- a/kit/utils/tab_completion.py
+++ b/kit/utils/tab_completion.py
@@ -18,7 +18,7 @@ try:
     from argcomplete import autocomplete
 except ImportError as e:
 
-    def autocomplete(arg):  # pylint: disable=unused-argument
+    def autocomplete(arg):  # type: ignore[misc]  # pylint: disable=unused-argument
         """Continue with the execution"""
 
 

--- a/tests/test_integration_wrong_inputs.py
+++ b/tests/test_integration_wrong_inputs.py
@@ -14,7 +14,6 @@ from kit.commands.install import install_components
 
 
 def test_debug_mode(tmp_path, hekit_path):
-
     config_file = create_config_file(tmp_path)
     madeup_filename = "MadeUpFileName"
     cmd = f"{hekit_path} --config {config_file} --debug install {madeup_filename}"


### PR DESCRIPTION
## Proposed changes

Deprecate support of HE-Toolkit on Ubuntu 20.04

The HE-Toolkit is now only tested on Ubuntu 22.04 with Clang 14.x and GCC 11.x

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/intel/he-toolkit/tree/main#contributing) section
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did, what alternatives you
considered, etc.
