### PR TITLE
override default base docker platform

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         - id: check-byte-order-marker
         - id: check-yaml
     - repo: https://github.com/crate-ci/typos
-      rev: v1.1.9
+      rev: v1.16.8
       hooks:
         - id: typos
     - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.5.0
+      rev: v4.4.0
       hooks:
         - id: trailing-whitespace
         - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         - id: end-of-file-fixer
         - id: check-merge-conflict
         - id: mixed-line-ending
-        - id: check-byte-order-marker
+        - id: fix-byte-order-marker
         - id: check-yaml
     - repo: https://github.com/crate-ci/typos
       rev: v1.16.8

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,6 @@
+[default]
+extend-ignore-re = ["helo byd"]
+
 [default.extend-identifiers]
 
 

--- a/deployments/config_psi/psi/tests/TestLookup.cpp
+++ b/deployments/config_psi/psi/tests/TestLookup.cpp
@@ -414,7 +414,7 @@ TEST(TestLookup, throwsWhenQueryBuilderExpectsMoreColumnsThanAvailable) {
   EXPECT_THROW(qb.build(db.columns()), helib::OutOfRangeError);
 }
 
-TEST(TestLookup, thowsWhenQueryHasMoreThanOneRow) {
+TEST(TestLookup, throwsWhenQueryHasMoreThanOneRow) {
   // clang-format off
   helib::Context context = helib::ContextBuilder<helib::BGV>()
                                .m(24)

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,7 +72,7 @@ container.
   processor with at least Intel AVX512DQ support.  For best performance, it is
   recommended to use processors supporting AVX512-IFMA52.
 - The docker build has been tested on,
-  - Ubuntu 20.04;
+  - Ubuntu 22.04;
   - MacOS Catalina (10.15.7).
 
 #### Running the Docker Build on MacOS
@@ -133,11 +133,11 @@ Code configuration.
 
 Once this step is successfully completed the program shall output
 ```bash
-Successfully tagged <username>/ubuntu_he_vscode:2.0.0
+Successfully tagged <username>/ubuntu_he_vscode:<hekit-version>
 
 RUN DOCKER CONTAINER ...
 Run container with
-docker run -d -p <ip addr>:<port>:8888 <username>/ubuntu_he_vscode:2.0.0
+docker run -d -p <ip addr>:<port>:8888 <username>/ubuntu_he_vscode:<hekit-version>
 Then to open vscode navigate to <ip addr>:<port> in your chosen browser
 ```
 
@@ -196,6 +196,16 @@ hekit docker-build --enable feature-one,feature-two,feature-three
 The toolkit will build the images in the order that they appear in the list,
 i.e. `feature-three` will be built on `feature-two` which will be built on
 `feature-one`.
+
+### Using custom base platform
+When building a docker image, `hekit` uses by default a version of Ubuntu as a
+base image that it fetches from dockerhub if it does not exist locally. This
+can be overridden as follows
+```bash
+hekit docker-build --platform <base-platform-image>
+```
+Note that this is at the user's own risk as the Dockerfiles have only been
+created with the default in mind.
 
 ## Running the Examples
 After a successful install and build of the docker container, the user should

--- a/docker/README.md
+++ b/docker/README.md
@@ -73,7 +73,6 @@ container.
   recommended to use processors supporting AVX512-IFMA52.
 - The docker build has been tested on,
   - Ubuntu 22.04;
-  - MacOS Catalina (10.15.7).
 
 #### Running the Docker Build on MacOS
 In order to successfully run the docker build on MacOS you may be required to
@@ -105,7 +104,7 @@ installation then you can install Docker directly from the official
 [instructions](https://docs.docker.com/engine/install/ubuntu/) to install on
 Ubuntu.
 
-**Note on macOS:** If running the docker build on Mac OSX, the UID and GID of
+**Note on MacOS:** If running the docker build on Mac OSX, the UID and GID of
 the user created in the docker container will both be set to 1000 by default.
 To override this value the user can simply pass in the desired UID/GID as
 follows

--- a/he-samples/examples/logistic-regression/README.md
+++ b/he-samples/examples/logistic-regression/README.md
@@ -7,7 +7,7 @@ build.
 This example is also capable of running linear regression instead of logistic
 regression. Logistic regression can be achieved by
 ["wrapping"](https://philippmuens.com/logistic-regression-from-scratch) a
-[mulitiple linear
+[multiple linear
 regression](https://en.wikipedia.org/wiki/Linear_regression#Simple_and_multiple_linear_regression)
 model with a [sigmoid
 function](https://en.wikipedia.org/wiki/Sigmoid_function). The sigmoid function

--- a/he-samples/examples/psi/src/psi.cpp
+++ b/he-samples/examples/psi/src/psi.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv) {
               << std::endl;
     return EXIT_FAILURE;
   } catch (const std::exception& e) {
-    std::cerr << "\nExit due to unkown exception thrown:\n\t" << e.what()
+    std::cerr << "\nExit due to unknown exception thrown:\n\t" << e.what()
               << std::endl;
     return EXIT_FAILURE;
   }

--- a/kit/PLUGINS.md
+++ b/kit/PLUGINS.md
@@ -145,7 +145,7 @@ def set_TBD_subparser(subparsers):
 
 In the previous code, the following conditions must be met:
 
-* The value of the first paramenter of `subparsers.add_parser` must be the
+* The value of the first parameter of `subparsers.add_parser` must be the
 same as the value of `name` defined in the TOML file.
 
 * `ADD_NEW_FUNCTIONALITY` (parameter `fn` of `set_defaults`) is the function

--- a/kit/README.md
+++ b/kit/README.md
@@ -45,7 +45,7 @@ each command.
 | check-dependencies | Checks system dependencies. | hekit check-dependencies dependencies-file
 | new | Create a new project. | hekit new [--directory DIRECTORY] [--based-on {logistic-regression,psi,secure-query}] name|
 | plugins | Handle third party plugins. See [Plugins](./PLUGINS.md). | hekit plugins {list,install,remove,enable,disable}
-| docker-build | Builds the HE Toolkit Docker container. See [Docker Build](../docker/README.md). | hekit docker-build [--id ID] [--clean] [--check-only] [--enable {vscode}]
+| docker-build | Builds the HE Toolkit Docker container. See [Docker Build](../docker/README.md). | hekit docker-build [--id ID] [--clean] [--check-only] [--enable {vscode,...}] [--platform PLATFORM]
 | gen-primes | Generates primes in range [n, m] where n, m are positive integers. See [Tools](./tools/README.md). | hekit gen-primes start stop
 | algebras  | Generates ZZ_p[x]/phi(X) algebras. . See [Tools](./tools/README.md). | hekit algebras [-p P] [-d D] [--no-corrected] [--no-header]
 

--- a/kit/commands/docker_build.py
+++ b/kit/commands/docker_build.py
@@ -185,7 +185,7 @@ def setup_docker(args):
     if isinstance(args.enable, dict):
         features.update(args.enable)
 
-    prev = "ubuntu:22.04"
+    prev = args.platform
     # Must make sure we have a platform image
     if not docker_tools.image_exists(prev):
         docker_tools.pull_base_image(prev)
@@ -249,6 +249,12 @@ def set_docker_subparser(subparsers):
         "--enable",
         type=get_docker_features,
         help=f"add/enable extra features in docker build of toolkit, choose from {get_feature_names()}",
+    )
+    parser_docker_build.add_argument(
+        "--platform",
+        type=str,
+        default="ubuntu:22.04",
+        help="pass different platform to build on",
     )
     parser_docker_build.add_argument(
         "-y", action="store_false", help="say yes to prompts"

--- a/kit/commands/docker_build.py
+++ b/kit/commands/docker_build.py
@@ -212,7 +212,7 @@ def setup_docker(args):
 
 
 def get_docker_features(keys: str) -> Dict[str, str]:
-    """Transform string of comma seperated features to enable into a dict with
+    """Transform string of comma separated features to enable into a dict with
     the keys as feature strings and values as locoations of the necessary
     Dockerfile"""
     tobj = toml.load(Constants.HEKIT_DOCKER_DIR / "dockerfiles.toml")

--- a/kit/commands/docker_build.py
+++ b/kit/commands/docker_build.py
@@ -254,7 +254,7 @@ def set_docker_subparser(subparsers):
         "--platform",
         type=str,
         default="ubuntu:22.04",
-        help="pass different platform to build on",
+        help="pass different platform to build on (default: '%(default)s')",
     )
     parser_docker_build.add_argument(
         "-y", action="store_false", help="say yes to prompts"

--- a/kit/utils/spec.py
+++ b/kit/utils/spec.py
@@ -118,7 +118,7 @@ def get_dependencies(instances_list: List) -> List[str]:
             if not symbols:
                 return
 
-            # Assume dependecies are define as:
+            # Assume dependencies are define as:
             # component/instance
             dependency_list.extend(d[k].split("/")[0] for _, k in symbols)
 

--- a/notes/GroupsNotes.tex
+++ b/notes/GroupsNotes.tex
@@ -338,7 +338,7 @@ If $G=\langle g\rangle$ is a cyclic group of order $n$, then $G$ has a subgroup 
 \end{theorem}
 The subgroup of order $d$ can be generated simply by $g^{\frac{n}{d}}$.
 
-As we saw above $\Z_{7}^{\times}$ is cyclic while $\Z_8^{\times}$ is not cylic. This is related to an important theorem about primitive elements modulo $n$ that we saw in the Number Theory section. In particular, we see that $\Z_n^{\times}$ is cyclic if and only if there is a primitive element modulo $n$. Thus we have the following theorem:
+As we saw above $\Z_{7}^{\times}$ is cyclic while $\Z_8^{\times}$ is not cyclic. This is related to an important theorem about primitive elements modulo $n$ that we saw in the Number Theory section. In particular, we see that $\Z_n^{\times}$ is cyclic if and only if there is a primitive element modulo $n$. Thus we have the following theorem:
 \begin{theorem}
 $\Z_n^{\times}$ is a cyclic group if and only if $n=2, 4, p^k$ or $2p^k$ where $p$ is an odd prime.
 \end{theorem}

--- a/notes/NumberTheoryNotes.tex
+++ b/notes/NumberTheoryNotes.tex
@@ -359,7 +359,7 @@ So $GCD(92,28)=4$. To find the coefficients $x, y$ in the Extended algorithm, we
 \end{example}
 
 \bigskip
-The algorithm can be used to prove the following observation aboout GCDs:
+The algorithm can be used to prove the following observation about GCDs:
 \begin{theorem}\label{factorout}
 If $k\in \N$ and $a, b$ are positive integers, then $(ka, kb) = k(a,b)$.
 \end{theorem}
@@ -717,7 +717,7 @@ We first cancel $3$, which leads to $3x\equiv 7 \pmod{10}$. Multiplying both sid
 \hrule
 \section{The Chinese Remainder Theorem}
 Chinese Remainder Theorem is about solving a system of linear congruences. We will see the theorem, some examples and an information security application of it.
-\begin{theorem} $($Chinese Remainder Thoerem: CRT $)$ \label{CRT} Ler $n_1, n_2, \dots, n_k$ be positive integers $>1$ so that $(n_i,n_j)=1$ for all $i, j$ with $i\neq j$. Then the system of congruence
+\begin{theorem} $($Chinese Remainder Theorem: CRT $)$ \label{CRT} Ler $n_1, n_2, \dots, n_k$ be positive integers $>1$ so that $(n_i,n_j)=1$ for all $i, j$ with $i\neq j$. Then the system of congruence
 \begin{align*}
     x &\equiv a_1 \pmod{n_1} \\
     x &\equiv a_2 \pmod{n_2} \\
@@ -1068,7 +1068,7 @@ We should remember that in any context that we are talking about $ord_n(a)$, we 
 \end{remark}
 Let us look at an example of finding the order in the light of the previous theorem:
 \begin{example}
-To find $ord_{18}(5)$ for example, using the previous thoerem, we know that $ord_{18}(5)|\phi(18)=6$. So we just need to check $5^2, 5^3$ modulo $18$. $5^2=25 \equiv 7 \pmod{18}$ and so $5^3 \equiv 35 \equiv 17 \pmod{18}$. This shows that $ord_{18}(5)\neq 1, 2$ or $3$, so we must have $ord_{18}(5)=6$.
+To find $ord_{18}(5)$ for example, using the previous theorem, we know that $ord_{18}(5)|\phi(18)=6$. So we just need to check $5^2, 5^3$ modulo $18$. $5^2=25 \equiv 7 \pmod{18}$ and so $5^3 \equiv 35 \equiv 17 \pmod{18}$. This shows that $ord_{18}(5)\neq 1, 2$ or $3$, so we must have $ord_{18}(5)=6$.
 \end{example}
 
 \bigskip

--- a/notes/RingsAndFieldsNotes.tex
+++ b/notes/RingsAndFieldsNotes.tex
@@ -107,7 +107,7 @@ Recall that a fully homomorphic encryption scheme supports two main operations, 
 \section{Rings: Definition and Examples}
 Let us start with the definition of a ring:
 \begin{definition}
-A nonempty set $R$ that is equipped with two binary operations (genericaly called ``addition" and ``multiplication") $+$ and $\cdot$ is called a {\bf ring} if ot satisfies the following conditions:
+A nonempty set $R$ that is equipped with two binary operations (genericaly called ``addition" and ``multiplication") $+$ and $\cdot$ is called a {\bf ring} if it satisfies the following conditions:
 \begin{enumerate}
     \item $(R,+)$ is an Abelian group
  \item $R$ is closed under multiplication, that is $a\cdot b \in R$ whenever $a,b\in R$
@@ -166,7 +166,7 @@ So,  just like a zero divisor is a divisor of $0$, a unit is a divisor of $1$.
 \begin{example}
 \begin{enumerate}
     \item In $\Z$, $1$ and $-1$ are the only units.
-    \item In $\Z_6$, $5$ is a unit since $5\cdot 5 =1$ in $\Z_6$. $2$ is not a unit since $2a$ will alwyas be $0,2$ or $4$ modulo $6$.
+    \item In $\Z_6$, $5$ is a unit since $5\cdot 5 =1$ in $\Z_6$. $2$ is not a unit since $2a$ will always be $0,2$ or $4$ modulo $6$.
     \item Recalling the Number Theory part, we see that $a\in \Z_n$ is a unit if and only $GCD(a,b)=1$.
     \item Thus in $\Z_p$, where $p$ is prime, every non-zero element is a unit.
     \item In $\Q$, $\R$ and in $\C$, every non-zero element is a unit.
@@ -277,7 +277,7 @@ A ring homomorphism $\varphi:R\rightarrow S$ is called an ``isomorphism" if it i
     \item As we saw before, the identity function is the only automorphism of $\Z$.
     \item Let us define $\varphi:\C \rightarrow \C$ by $\varphi(a+bi)=a-bi$, that is $\varphi$ is the complex conjugation operation. It is easy to see that complex conjugation is both additive and multiplicative and hence is a ring homomorphism. Moreover, it is one-to-one and onto since $a-bi=c-di$ implies $a=c$ and $b=d$ and $\varphi(a-bi)=a+bi$. Thus $\varphi$ is an automorphism of $\C$.
     \item This next example will illustrate how the Chinese Remainder Theorem gives rise to an isomorphism of rings:
-    Consider the fuction $\varphi:\Z_{12}\rightarrow \Z_{3}\times \Z_{4}$, where we consider $\Z_3\times \Z_4$ to be a ring with respect to component-wise addition and multiplication modulo 3 and 4 respectively. Such rings are called ``product rings".
+    Consider the function $\varphi:\Z_{12}\rightarrow \Z_{3}\times \Z_{4}$, where we consider $\Z_3\times \Z_4$ to be a ring with respect to component-wise addition and multiplication modulo 3 and 4 respectively. Such rings are called ``product rings".
     We define $\varphi$ by $\varphi(m) = (m_3, m_4)$, where $m_3$ and $m_4$ represent the reduction modulo $3$ and modulo $4$, respectively.
 
     Since modulo reduction is both multiplicative and additive, this is clearly a ring homomorphism. By Chinese Remainder Theorem, for any $a \in \Z_3$ and $b\in \Z_4$, there is a unique solution to  $x\equiv a \pmod{3}$ and $x\equiv b\pmod{4}$ in $\Z_{12}$. Thus this map is one-to-one and it is also onto. Hence $\varphi$ is an isomorphism.
@@ -591,7 +591,7 @@ $GCD(a_0, a_1, \dots, a_n)=1$, then $p(x)$ is irreducible in $\Z[x]$ if and only
 \end{theorem}
 The reason why this theorem is important is because of the following results:
 \begin{theorem}\label{irmax}
-If $F$ is a field then $F[x]$ has the Euclidean division algorithm and hence is a Principle Ideal Domain (PID). Morevoer, $p(x)\in F[x]$ is irreducible if and only if $(p(x))$ is a maximal ideal.
+If $F$ is a field then $F[x]$ has the Euclidean division algorithm and hence is a Principle Ideal Domain (PID). Moreover, $p(x)\in F[x]$ is irreducible if and only if $(p(x))$ is a maximal ideal.
 \end{theorem}
 So, having irreducible polynomials will help us generate maximal ideals.
 \begin{remark}
@@ -599,7 +599,7 @@ The previous theorem is not true when $F$ is not a field. For example, in $\Z[x]
 \end{remark}
 
 \begin{observation}
-Irreducibility depends on the coefficent ring. For example, the polynomial $p(x)=x^2+1$ is irreducible in $\Z[x]$ as well as in $\Q[x]$. However, it is reducible in $\Z_2[x]$ as
+Irreducibility depends on the coefficient ring. For example, the polynomial $p(x)=x^2+1$ is irreducible in $\Z[x]$ as well as in $\Q[x]$. However, it is reducible in $\Z_2[x]$ as
 $$x^2+1=(x+1)^2$$
 in $\Z_2[x]$.
 \end{observation}
@@ -674,7 +674,7 @@ Let us consider several such examples:
     \item The example we saw above, namely $\{0,1,\omega, 1+\omega\}$ is just $\Z_2[x]/(x^2+x+1)$.
     \item Now let us construct a finite field of size $8$. As we saw in the previous section, $x^3+x+1$ is irreducible over $\Z_2$. So we can construct a finite field of size $8$ by letting $F= \Z_2[x]/(x^3+x+1)$.
     So, letting $\omega = x+(x^3+x+1)$, we see that $\omega^3=\omega+1$ and thus we have
-    $$F = \{0,1, \omega, \omega ^2, 1+\omega, 1+\omega^2, \omega+\omega^2, 1+\omega+\omega^2\}.$$ So how do we add and mutliply? Addition is done just like in a vector space. However, when multiplying, we need to remember that in this field $\omega^3=\omega+1$, $\omega^4=\omega^2+\omega$, $\omega^5 = \omega^3+\omega^2= \omega^2+\omega+1$, etc.  In fact let us write the addition and multiplication tables:
+    $$F = \{0,1, \omega, \omega ^2, 1+\omega, 1+\omega^2, \omega+\omega^2, 1+\omega+\omega^2\}.$$ So how do we add and multiply? Addition is done just like in a vector space. However, when multiplying, we need to remember that in this field $\omega^3=\omega+1$, $\omega^4=\omega^2+\omega$, $\omega^5 = \omega^3+\omega^2= \omega^2+\omega+1$, etc.  In fact let us write the addition and multiplication tables:
 
 
 \begin{table}[H]

--- a/notes/RingsAndFieldsPresentation.tex
+++ b/notes/RingsAndFieldsPresentation.tex
@@ -211,7 +211,7 @@ Rings and Fields Fundamentals for Homomorphic Encryption}
 \begin{stepitemize}
 \item Let us start with the definition of a ring:
 \begin{definition}
-A nonempty set $R$ that is equipped with two binary operations (genericaly called ``addition" and ``multiplication") $+$ and $\cdot$ is called a {\bf ring} if ot satisfies the following conditions:
+A nonempty set $R$ that is equipped with two binary operations (genericaly called ``addition" and ``multiplication") $+$ and $\cdot$ is called a {\bf ring} if it satisfies the following conditions:
 \begin{enumerate}
     \item $(R,+)$ is an Abelian group
  \item $R$ is closed under multiplication, that is $a\cdot b \in R$ whenever $a,b\in R$
@@ -276,7 +276,7 @@ A nonempty set $R$ that is equipped with two binary operations (genericaly calle
 \item An element $a\in R$ is said to be a ``unit" if there exits $b\in R$ such that $ab=1$.
 \item So,  just like a zero divisor is a divisor of $0$, a unit is a divisor of $1$.
 \item In $\Z$, $1$ and $-1$ are the only units.
-    \item In $\Z_6$, $5$ is a unit since $5\cdot 5 =1$ in $\Z_6$. $2$ is not a unit since $2a$ will alwyas be $0,2$ or $4$ modulo $6$.
+    \item In $\Z_6$, $5$ is a unit since $5\cdot 5 =1$ in $\Z_6$. $2$ is not a unit since $2a$ will always be $0,2$ or $4$ modulo $6$.
     \item Recalling the Number Theory part, we see that $a\in \Z_n$ is a unit if and only $GCD(a,b)=1$.
     \item Thus in $\Z_p$, where $p$ is prime, every non-zero element is a unit.
     \item In $\Q$, $\R$ and in $\C$, every non-zero element is a unit.
@@ -868,7 +868,7 @@ $p(x)=x^2+x+1$ is irreducible in $\Z_2[x]$ since $p(0)=p(1)=1$, which means $p$ 
 
     \item So, letting $\omega = x+(x^3+x+1)$, we see that $\omega^3=\omega+1$ and thus we have
     $$F = \{0,1, \omega, \omega ^2, 1+\omega, 1+\omega^2, \omega+\omega^2, 1+\omega+\omega^2\}.$$
-    \item How do we add and mutliply?
+    \item How do we add and multiply?
     \item Addition is done just like in a vector space. \item However, when multiplying, we need to remember that in this field $\omega^3=\omega+1$, $\omega^4=\omega^2+\omega$, $\omega^5 = \omega^3+\omega^2= \omega^2+\omega+1$, etc.
 \end{stepitemize}
 \end{frame}

--- a/tests/test_cmd_docker_build.py
+++ b/tests/test_cmd_docker_build.py
@@ -301,6 +301,7 @@ class MockArgs:
         self.enable = enable
         self.id = 1
         self.version = "2.0.0"
+        self.platform = "ubuntu:22.04"
 
 
 class MockDockerTools:

--- a/tests/test_integration_docker.py
+++ b/tests/test_integration_docker.py
@@ -100,6 +100,7 @@ class MockArgs:
         self.version = False
         self.debug = False
         self.y = True
+        self.platform = True
 
 
 class Mockers:

--- a/tests/test_util_spec.py
+++ b/tests/test_util_spec.py
@@ -107,7 +107,7 @@ def test_write_spec_to_toml_file(create_basic_spec_file, tmp_path):
 
 def test_dependency_substitutions_are_expanded(tmp_path):
     """Dependency substitutions cross component boundaries"""
-    # Create a depedency
+    # Create a dependency
     dep = {"hexl": [{"name": "bob", "export_thing": "someinfo"}]}
     rloc = tmp_path.resolve()
     # component / instance
@@ -115,7 +115,7 @@ def test_dependency_substitutions_are_expanded(tmp_path):
     # Creates missing directories
     dep_loc.mkdir(parents=True)
     dep_spec = Spec.from_instance_spec("hexl", dep["hexl"][0], rloc, recipe_arg_dict={})
-    # Write depedency spec to file
+    # Write dependency spec to file
     dep_spec.to_toml_file((dep_loc / "hekit.spec").resolve())
 
     expected = {


### PR DESCRIPTION
## Proposed changes

For better flexibility, add this feature to override explictely the docker base platform.
Also updated pre-commit config leading to many typos found across codebase.

## Types of changes

What types of changes does your code introduce to the HE Toolkit project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/intel/he-toolkit/tree/main#contributing) section
- [ ] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did, what alternatives you
considered, etc.
