### PR TITLE
Move HE samples to separate docker layer

### DIFF
--- a/docker/Dockerfile.samples
+++ b/docker/Dockerfile.samples
@@ -1,0 +1,28 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+ARG CUSTOM_FROM
+
+FROM $CUSTOM_FROM
+
+LABEL maintainer="https://github.com/intel/he-toolkit"
+
+# User setup
+ARG UNAME
+ARG UID
+ARG GID
+ARG HOME="/home/$UNAME"
+ENV SHELL="/bin/bash"
+
+# Switch user to $UNAME
+USER $UNAME
+
+# Change directories to $HOME/he-toolkit
+WORKDIR $HOME/he-toolkit
+
+# Build and install libraries, examples, and kernels
+RUN ./hekit install recipes/default.toml && \
+    ./hekit build recipes/examples.toml --recipe_arg "toolkit-path=${HOME}/he-toolkit" && \
+    ./hekit build recipes/sample-kernels.toml --recipe_arg "toolkit-path=${HOME}/he-toolkit"
+
+ENTRYPOINT . docker/runners.sh && welcome_message && cd $HOME && /bin/bash

--- a/docker/Dockerfile.toolkit
+++ b/docker/Dockerfile.toolkit
@@ -45,9 +45,6 @@ RUN ["pip", "install", "toml", "argcomplete"]
 WORKDIR $HOME/he-toolkit
 
 # Initialize hekit and install librares, examples, and kernels
-RUN echo "y" | ./hekit init --default-config && \
-    ./hekit install recipes/default.toml && \
-    ./hekit build recipes/examples.toml --recipe_arg "toolkit-path=${HOME}/he-toolkit" && \
-    ./hekit build recipes/sample-kernels.toml --recipe_arg "toolkit-path=${HOME}/he-toolkit"
+RUN echo "y" | ./hekit init --default-config
 
 ENTRYPOINT . docker/runners.sh && welcome_message && cd $HOME && /bin/bash

--- a/docker/Dockerfile.vscode
+++ b/docker/Dockerfile.vscode
@@ -27,7 +27,6 @@ RUN for e in vscode.cpp twxs.cmake ms-vscode.cmake-tools vadimcn.vscode-lldb; do
       code-server --user-data-dir=$HOME/ --install-extension $e; \
     done
 
-
 # Update code-server user settings
 RUN echo '{"extensions.autoUpdate": false, "workbench.colorTheme": "Default Dark+"}' |\
     jq . > $HOME/User/settings.json && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,6 +11,7 @@
     - [Steps](#steps)
     - [Using VS Code Server](#using-vs-code-server)
     - [Using Custom Dockerfiles](#using-custom-dockerfiles)
+    - [Using a Custom Base Platform](#using-a-custom-base-platform)
   - [Running the Examples](#running-the-examples)
     - [Docker Controls](#docker-controls)
       - [Commands used inside the Docker Container](#commands-used-inside-the-docker-container)
@@ -90,9 +91,21 @@ on `Apply & Restart`.
   memory. This can be done via the `Resources` tab under `Preferences`.
 
 ### Steps
-To build and run the Intel HE Toolkit container run
+To build the base docker container run
 ```bash
 hekit docker-build
+```
+This will build a base image containing the necessary dependencies and then an
+image containing the HE Toolkit repository with the `hekit` command enabled.
+This can be useful as a base for users to use the HE Toolkit to build a subset
+of the provided sample kernels and examples or an entirely custom HE project of
+their choosing.
+
+If a full installation of the sample kernels, examples, and supported HE
+libraries is desired then build the Intel HE Toolkit container in its entirety
+with
+```bash
+hekit docker-build --enable samples
 ```
 The installation should take a few minutes and once successful will run the
 container as the current user. This will be signified with the printing of the
@@ -112,11 +125,11 @@ follows
 hekit docker-build --id 1234
 ```
 
-After the image has been successfully built, the below message will be
-displayed
+After the image has been successfully built, the below message or a variation
+will be displayed
 ```bash
 Run container with
-docker run -it <username>/ubuntu_he_toolkit:<hekit-version>
+docker run -it <username>/ubuntu_he_samples:<hekit-version>
 ```
 Executing this command shall start the container using `bash`.
 
@@ -126,6 +139,10 @@ Code IDE via [code-server](https://coder.com/docs/code-server/latest) instead
 of directly via the command line. To enable this run
 ```bash
 hekit docker-build --enable vscode
+```
+or alternatively to include pre-built samples and examples
+```bash
+hekit docker-build --enable samples,vscode
 ```
 This will build an extra layer on top of the previous images containing a VS
 Code configuration.
@@ -196,7 +213,7 @@ The toolkit will build the images in the order that they appear in the list,
 i.e. `feature-three` will be built on `feature-two` which will be built on
 `feature-one`.
 
-### Using custom base platform
+### Using a Custom Base Platform
 When building a docker image, `hekit` uses by default a version of Ubuntu as a
 base image that it fetches from dockerhub if it does not exist locally. This
 can be overridden as follows

--- a/docker/dockerfiles.toml
+++ b/docker/dockerfiles.toml
@@ -3,4 +3,5 @@
 #   `hekit docker-build --enable <custom-feature>`
 # NOTE: Paths must be absolute
 
+samples = "${HEKITPATH}/docker/Dockerfile.samples"
 vscode = "${HEKITPATH}/docker/Dockerfile.vscode"

--- a/docker/repo-inventory.txt
+++ b/docker/repo-inventory.txt
@@ -48,6 +48,7 @@ deployments/config_psi/setenv.sh
 deployments/config_psi/tests/test_config_psi.py
 dev_reqs.txt
 docker/Dockerfile.base
+docker/Dockerfile.samples
 docker/Dockerfile.toolkit
 docker/Dockerfile.vscode
 docker/README.md


### PR DESCRIPTION
## Proposed changes

Separating out the installation of he-samples in `Dockerfile.toolkit` to its own docker file `Dockerfile.samples` and making it an optional layer in the docker build.

## Types of changes

What types of changes does your code introduce to the HE Toolkit project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/intel/he-toolkit/tree/main#contributing) section
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

`Dockerfile.toolkit` now just sets up the `hekit` command. Making the `samples` layer optional allows more flexibility for the user to be able to install/build a custom project or subset of the `default.toml` recipe file.
